### PR TITLE
fixing typings errors

### DIFF
--- a/lib/structures/Channel.ts
+++ b/lib/structures/Channel.ts
@@ -14,8 +14,8 @@ export class Channel extends Base {
     type: string;
     /** Channel name */
     name: string;
-    /** Channel topic/description */
-    topic: string | null;
+    /** Channel description */
+    description: string | null;
     /** Timestamp (unix epoch time) of the channel's creation. */
     _createdAt: number;
     /** ID of the channel's creator. */
@@ -45,7 +45,7 @@ export class Channel extends Base {
         this.data = data;
         this.type = data.type;
         this.name = data.name;
-        this.topic = data.topic ?? null;
+        this.description = data.topic ?? null;
         this._createdAt = Date.parse(data.createdAt);
         this.memberID = data.createdBy;
         this._updatedAt = data.updatedAt ? Date.parse(data.updatedAt) : null;

--- a/lib/types/events.d.ts
+++ b/lib/types/events.d.ts
@@ -34,15 +34,15 @@ export interface ClientEvents {
     /** @event Emitted when a guild channel is deleted. */
     channelDelete: [channel: Channel];
     /** @event Emitted when a forum thread is created. */
-    forumThreadCreate: [topic: ForumThread];
+    forumThreadCreate: [thread: ForumThread];
     /** @event Emitted when a forum thread is edited. */
-    forumThreadUpdate: [topic: ForumThread];
+    forumThreadUpdate: [thread: ForumThread];
     /** @event Emitted when a forum thread is deleted. */
-    forumThreadDelete: [topic: ForumThread];
+    forumThreadDelete: [thread: ForumThread];
     /** @event Emitted when a forum thread is pinned. */
-    forumThreadPin: [topic: ForumThread];
+    forumThreadPin: [thread: ForumThread];
     /** @event Emitted when a forum thread is unpinned. */
-    forumThreadUnpin: [topic: ForumThread];
+    forumThreadUnpin: [thread: ForumThread];
     /** @event Emitted when a thread comment is created. */
     forumCommentCreate: [comment: ForumThreadComment];
     /** @event Emitted when forum thread comment is edited. */


### PR DESCRIPTION
* Removed `Channel.topic` property, replaced by `Channel.description`
* Fixed event typings error, parameter renamed from topic to thread (forumThreadCreate, forumThreadUpdate, forumThreadDelete, forumThreadPin, forumThreadUnpin).