### PR TITLE
fixing ClientEvent imports & typings changes.

### DIFF
--- a/lib/gateway/events/GuildHandler.ts
+++ b/lib/gateway/events/GuildHandler.ts
@@ -53,7 +53,7 @@ export class GuildHandler extends GatewayEventHandler{
         const GuildComponent = new Guild(data.server, this.client);
         const output = {
             guild:     GuildComponent,
-            createdBy: data.createdBy
+            inviterID: data.createdBy
         };
         this.client.emit("guildCreate", output as GuildCreateInfo);
     }

--- a/lib/rest/RESTManager.ts
+++ b/lib/rest/RESTManager.ts
@@ -25,10 +25,16 @@ export class RESTManager {
         this.misc = new Miscellaneous(this);
     }
 
+    /** Send an authenticated request.
+     * @param options Request options.
+     */
     async authRequest<T = unknown>(options: Omit<RequestOptions, "auth">): Promise<T> {
         return this.handler.authRequest<T>(options);
     }
 
+    /** Send a request.
+     * @param options Request options.
+     */
     async request<T = unknown>(options: RequestOptions): Promise<T> {
         return this.handler.request<T>(options);
     }

--- a/lib/structures/BannedMember.ts
+++ b/lib/structures/BannedMember.ts
@@ -12,10 +12,10 @@ export class BannedMember extends User {
     ban: {
         /** Reason of the ban */
         reason?: string;
-        /** Timestamp (unix epoch time) of when the member has been banned. */
-        createdAt: number|null;
-        /** ID of the member that banned the user. */
-        createdBy: string;
+        /** When the member has been banned. */
+        createdAt: Date | null;
+        /** ID of the member who banned this member. */
+        bannedBy: string;
     };
     /**
      * @param guildID ID of the guild.
@@ -27,8 +27,8 @@ export class BannedMember extends User {
         this.guildID = guildID;
         this.ban = {
             reason:    data.reason,
-            createdAt: data.createdAt ? Date.parse(data.createdAt) : null,
-            createdBy: data.createdBy
+            createdAt: data.createdAt ? new Date(data.createdAt) : null,
+            bannedBy:  data.createdBy
         };
     }
 

--- a/lib/structures/CalendarEvent.ts
+++ b/lib/structures/CalendarEvent.ts
@@ -28,16 +28,16 @@ export class CalendarEvent extends Base {
     /** Limit of event entry. */
     rsvpLimit: number | null;
     /** Timestamp (unix epoch time) of the event starting time.*/
-    _startsAt: number|null;
+    startsAt: Date | null;
     /** Duration in *ms* of the event. */
     duration: number;
     /** */
     isPrivate: boolean;
     mentions: APIMentions | null;
-    /** Timestamp (unix epoch time) of the event's creation. */
-    _createdAt: number|null;
-    /** ID of the member that created the event. */
-    memberID: string;
+    /** When the event was created. */
+    createdAt: Date | null;
+    /** ID of the owner of this event. */
+    ownerID: string;
     /** Details about event cancelation (if canceled) */
     cancelation: APICalendarEvent["cancellation"] | null;
 
@@ -57,32 +57,27 @@ export class CalendarEvent extends Base {
         this.url = data.url ?? null;
         this.color = data.color ?? null;
         this.rsvpLimit = data.rsvpLimit ?? null;
-        this._startsAt = data.startsAt ? Date.parse(data.startsAt) : null;
+        this.startsAt = data.startsAt ? new Date(data.startsAt) : null;
         this.duration = (data.duration as number) * 60000 ?? null; // in ms.
         this.isPrivate = data.isPrivate ?? false;
         this.mentions = data.mentions ?? null;
-        this._createdAt = data.createdAt ? Date.parse(data.createdAt) : null;
-        this.memberID = data.createdBy;
+        this.createdAt = data.createdAt ? new Date(data.createdAt) : null;
+        this.ownerID = data.createdBy;
         this.cancelation = data.cancellation ?? null;
     }
 
-    /** Retrieve message's member, if cached.
+    /** Retrieve the event's owner, if cached.
      *
      * Note: this getter can output: Member, User, Promise<Member> or undefined.
      */
-    get member(): Member | User | Promise<Member> | undefined {
-        if (this.client.cache.members.get(this.memberID) && this.memberID){
-            return this.client.cache.members.get(this.memberID);
-        } else if (this.client.cache.users.get(this.memberID) && this.memberID){
-            return this.client.cache.users.get(this.memberID);
-        } else if (this.memberID && this.guildID){
-            return this.client.rest.guilds.getMember(this.guildID, this.memberID);
+    get owner(): Member | User | Promise<Member> | undefined {
+        if (this.client.cache.members.get(this.ownerID) && this.ownerID){
+            return this.client.cache.members.get(this.ownerID);
+        } else if (this.client.cache.users.get(this.ownerID) && this.ownerID){
+            return this.client.cache.users.get(this.ownerID);
+        } else if (this.ownerID && this.guildID){
+            return this.client.rest.guilds.getMember(this.guildID, this.ownerID);
         }
-    }
-
-    /** string representation of the _createdAt timestamp */
-    get createdAt(): Date|number|null{
-        return this._createdAt ? new Date(this._createdAt) : null;
     }
 
     /** Edit this event */

--- a/lib/structures/CalendarRSVP.ts
+++ b/lib/structures/CalendarRSVP.ts
@@ -1,9 +1,6 @@
 /** @module CalendarRSVP */
 import { Client } from "./Client";
-import { Member } from "./Member";
 import { Base } from "./Base";
-
-import { User } from "./User";
 import { APICalendarEventRSVP, APICalendarEventRSVPStatuses, PUTCalendarEventRSVPBody } from "../Constants";
 
 /** CalendarEventRSVP represents a guild member's event RSVP.
@@ -16,15 +13,15 @@ export class CalendarEventRSVP extends Base {
     guildID: string;
     /** Calendar channel id. */
     channelID: string;
-    /** RSVP member id */
-    memberID: string;
+    /** ID of the entity assigned to this Event RSVP. */
+    entityID: string;
     /** Status of the RSVP */
     status: APICalendarEventRSVPStatuses;
-    /** Timestamp (unix epoch time) of the rsvp's creation. */
-    _createdAt: number|null;
-    /** ID of the member that created the rsvp. */
-    createdBy: string;
-    /** ID of the member that updated the rsvp (if updated) */
+    /** When the RSVP was created. */
+    createdAt: Date | null;
+    /** ID of the user who created this RSVP. */
+    creatorID: string;
+    /** ID of the member who updated the rsvp, if updated. */
     updatedBy?: string | null;
 
     /**
@@ -36,39 +33,20 @@ export class CalendarEventRSVP extends Base {
         this.data = data;
         this.guildID = data.serverId;
         this.channelID = data.channelId;
-        this.memberID = data.userId;
+        this.entityID = data.userId;
         this.status = data.status;
-        this.createdBy = data.createdBy ?? null;
+        this.creatorID = data.createdBy ?? null;
         this.updatedBy = data.updatedBy ?? null;
-        this._createdAt = data.createdAt ? Date.parse(data.createdAt) : null;
-    }
-
-    /** Retrieve message's member, if cached.
-     *
-     * Note: this getter can output: Member, User, Promise<Member> or undefined.
-     */
-    get member(): Member | User | Promise<Member> | undefined {
-        if (this.client.cache.members.get(this.memberID) && this.memberID){
-            return this.client.cache.members.get(this.memberID);
-        } else if (this.client.cache.users.get(this.memberID) && this.memberID){
-            return this.client.cache.users.get(this.memberID);
-        } else if (this.memberID && this.guildID){
-            return this.client.rest.guilds.getMember(this.guildID, this.memberID);
-        }
-    }
-
-    /** String representation of the _createdAt timestamp. */
-    get createdAt(): Date|null{
-        return this._createdAt ? new Date(this._createdAt) : null;
+        this.createdAt = data.createdAt ? new Date(data.createdAt) : null;
     }
 
     /** Edit this RSVP. */
     async edit(options: PUTCalendarEventRSVPBody): Promise<CalendarEventRSVP>{
-        return this.client.rest.channels.editCalendarRsvp(this.channelID, this.id as number, this.memberID, options);
+        return this.client.rest.channels.editCalendarRsvp(this.channelID, this.id as number, this.entityID, options);
     }
 
     /** Delete this RSVP. */
     async delete(): Promise<void>{
-        return this.client.rest.channels.deleteCalendarRsvp(this.channelID, this.id as number, this.memberID);
+        return this.client.rest.channels.deleteCalendarRsvp(this.channelID, this.id as number, this.entityID);
     }
 }

--- a/lib/structures/Channel.ts
+++ b/lib/structures/Channel.ts
@@ -8,20 +8,18 @@ import type { APIGuildChannel } from "../Constants";
 
 /** Represents a guild channel. */
 export class Channel extends Base {
-    /** Raw data */
-    data: APIGuildChannel;
     /** Channel type */
     type: string;
     /** Channel name */
     name: string;
     /** Channel description */
     description: string | null;
-    /** Timestamp (unix epoch time) of the channel's creation. */
-    _createdAt: number;
-    /** ID of the channel's creator. */
-    memberID: string;
-    /** Timestamp (unix epoch time) of the channel's edition. (if edited) */
-    _updatedAt: number|null;
+    /** When this channel was created. */
+    createdAt: Date;
+    /** ID of the member who created this channel. */
+    creatorID: string;
+    /** Timestamp at which this channel was last edited. */
+    editedTimestamp: Date | null;
     /** Server ID */
     guildID: string;
     /** ID of the parent category. */
@@ -33,8 +31,8 @@ export class Channel extends Base {
     isPublic: boolean;
     /** ID of the member that archived the channel (if archived) */
     archivedBy: string | null;
-    /** Timestamp (unix epoch time) of when the channel has been archived. */
-    _archivedAt: number|null;
+    /** When the channel was last archived. */
+    archivedAt: Date | null;
 
     /**
      * @param data raw data
@@ -42,35 +40,19 @@ export class Channel extends Base {
      */
     constructor(data: APIGuildChannel, client: Client){
         super(data.id, client);
-        this.data = data;
         this.type = data.type;
         this.name = data.name;
         this.description = data.topic ?? null;
-        this._createdAt = Date.parse(data.createdAt);
-        this.memberID = data.createdBy;
-        this._updatedAt = data.updatedAt ? Date.parse(data.updatedAt) : null;
+        this.createdAt = new Date(data.createdAt);
+        this.creatorID = data.createdBy;
+        this.editedTimestamp = data.updatedAt ? new Date(data.updatedAt) : null;
         this.guildID = data.serverId;
         this.parentID = data.parentId ?? null;
         this.categoryID = data.categoryId ?? null;
         this.groupID = data.groupId;
         this.isPublic = data.isPublic ?? false;
         this.archivedBy = data.archivedBy ?? null;
-        this._archivedAt = data.archivedAt ? Date.parse(data.archivedAt) : null;
-    }
-
-    /** Date of the channel's creation. */
-    get createdAt(): Date{
-        return new Date(this._createdAt);
-    }
-
-    /** Date of the channel's last edition, if updated. */
-    get updatedAt(): Date|null{
-        return this._updatedAt !== null ? new Date(this._updatedAt) : null;
-    }
-
-    /** Date of when the channel got archived, if archived. */
-    get archivedAt(): Date|null{
-        return this._archivedAt !== null ? new Date(this._archivedAt) : null;
+        this.archivedAt = data.archivedAt ? new Date(data.archivedAt) : null;
     }
 
     /** Create a message in the channel. */

--- a/lib/structures/Doc.ts
+++ b/lib/structures/Doc.ts
@@ -49,7 +49,7 @@ export class Doc extends Base {
     }
 
     /** Retrieve the member who executed this action.
-     * Note: If this doc has been edited, the updatedAt id will be used to get you the member.
+     * Note: If this doc has been edited, the updatedBy id will be used to get you the member.
      */
     get member(): Member | User | Promise<Member> | undefined {
         if (this.client.cache.members.get(this.updatedBy ?? this.memberID)){

--- a/lib/structures/Doc.ts
+++ b/lib/structures/Doc.ts
@@ -13,22 +13,20 @@ export class Doc extends Base {
     guildID: string;
     /** ID of the 'docs' channel. */
     channelID: string;
-    /** Doc title/name */
-    title: string;
-    /** Doc title/name */
+    /** Doc name */
     name: string;
     /** Content of the doc */
     content: string;
     /** Doc mentions  */
     mentions: APIMentions;
-    /** Timestamp (unix epoch time) of the doc's creation. */
-    _createdAt: number|null;
-    /** ID of the member who created the doc. */
+    /** When the doc has been created. */
+    createdAt: Date;
+    /** ID of the member who created this doc. */
     memberID: string;
-    /** Timestamp (unix epoch time) of when the doc was updated. (if updated) */
-    _updatedAt?: number | null;
-    /** ID of the member who updated the doc. (if updated) */
-    updatedBy?: string | null;
+    /** When the doc has been updated. */
+    editedTimestamp: Date | null;
+    /** ID of the member who updated the doc. */
+    updatedBy: string | null;
 
     /**
      * @param data raw data
@@ -39,12 +37,11 @@ export class Doc extends Base {
         this.guildID = data.serverId;
         this.channelID = data.channelId;
         this.name = data.title ?? null;
-        this.title = data.title ?? null; // same as name, different type.
         this.content = data.content ?? null;
         this.mentions = data.mentions ?? {};
-        this._createdAt = data.createdAt ? Date.parse(data.createdAt) : null;
+        this.createdAt = new Date(data.createdAt);
         this.memberID = data.createdBy;
-        this._updatedAt = data.updatedAt ? Date.parse(data.updatedAt) : null;
+        this.editedTimestamp = data.updatedAt ? new Date(data.updatedAt) : null;
         this.updatedBy = data.updatedBy ?? null;
     }
 
@@ -59,16 +56,6 @@ export class Doc extends Base {
         } else if (this.guildID){
             return this.client.rest.guilds.getMember(this.guildID, this.updatedBy ?? this.memberID);
         } else throw new Error("ERROR: Couldn't get member, failed to retrieve member.");
-    }
-
-    /** Date of this doc's creation. */
-    get createdAt(): Date | null {
-        return this._createdAt ? new Date(this._createdAt) : null;
-    }
-
-    /** Date of this last doc's edition, if updated. */
-    get updatedAt(): Date | null {
-        return this._updatedAt ? new Date(this._updatedAt) : null;
     }
 
     /** Edit this doc.

--- a/lib/structures/ForumThread.ts
+++ b/lib/structures/ForumThread.ts
@@ -20,8 +20,8 @@ export class ForumThread extends Base {
     name: string;
     /** Timestamp (unix epoch time) of the thread's creation. */
     _createdAt: number;
-    /** ID of the member who created the thread */
-    memberID: string;
+    /** The ID of the owner of this thread. */
+    ownerID: string;
     /** ID of the webhook that created the thread (if created by webhook) */
     webhookID: string | null;
     /** Timestamp (unix epoch time) of when the thread got updated. (if updated) */
@@ -43,7 +43,7 @@ export class ForumThread extends Base {
         this.channelID = data.channelId;
         this.name = data.title;
         this._createdAt = Date.parse(data.createdAt);
-        this.memberID = data.createdBy;
+        this.ownerID = data.createdBy;
         this.webhookID = data.createdByWebhookId ?? null;
         this._updatedAt = data.updatedAt ? Date.parse(data.updatedAt) : null;
         this.bumpedAt = data.bumpedAt ?? null;
@@ -58,17 +58,17 @@ export class ForumThread extends Base {
         return this.client.cache.guilds.get(this.guildID) ?? this.client.rest.guilds.getGuild(this.guildID);
     }
 
-    /** Retrieve message's member, if cached.
+    /** Retrieve thread's owner, if cached.
      * If there is no cached member or user, this will make a request which returns a Promise.
      * If the request fails, this will throw an error or return you undefined as a value.
      */
-    get member(): Member | User | Promise<Member> | undefined {
-        if (this.client.cache.members.get(this.memberID) && this.memberID){
-            return this.client.cache.members.get(this.memberID);
-        } else if (this.client.cache.users.get(this.memberID) && this.memberID){
-            return this.client.cache.users.get(this.memberID);
-        } else if (this.memberID && this.guildID){
-            return this.client.rest.guilds.getMember(this.guildID, this.memberID);
+    get owner(): Member | User | Promise<Member> | undefined {
+        if (this.client.cache.members.get(this.ownerID) && this.ownerID){
+            return this.client.cache.members.get(this.ownerID);
+        } else if (this.client.cache.users.get(this.ownerID) && this.ownerID){
+            return this.client.cache.users.get(this.ownerID);
+        } else if (this.ownerID && this.guildID){
+            return this.client.rest.guilds.getMember(this.guildID, this.ownerID);
         }
     }
 

--- a/lib/structures/ForumThread.ts
+++ b/lib/structures/ForumThread.ts
@@ -18,8 +18,6 @@ export class ForumThread extends Base {
     channelID: string;
     /** Thread name/title */
     name: string;
-    /** Thread name/title */
-    title: string;
     /** Timestamp (unix epoch time) of the thread's creation. */
     _createdAt: number;
     /** ID of the member who created the thread */
@@ -44,7 +42,6 @@ export class ForumThread extends Base {
         this.guildID = data.serverId;
         this.channelID = data.channelId;
         this.name = data.title;
-        this.title = data.title;
         this._createdAt = Date.parse(data.createdAt);
         this.memberID = data.createdBy;
         this.webhookID = data.createdByWebhookId ?? null;

--- a/lib/structures/ForumThread.ts
+++ b/lib/structures/ForumThread.ts
@@ -16,16 +16,16 @@ export class ForumThread extends Base {
     guildID: string;
     /** Forum channel id */
     channelID: string;
-    /** Thread name/title */
+    /** Name of the thread */
     name: string;
-    /** Timestamp (unix epoch time) of the thread's creation. */
-    _createdAt: number;
+    /** When this forum thread was created. */
+    createdAt: Date;
     /** The ID of the owner of this thread. */
     ownerID: string;
     /** ID of the webhook that created the thread (if created by webhook) */
     webhookID: string | null;
-    /** Timestamp (unix epoch time) of when the thread got updated. (if updated) */
-    _updatedAt: number| null;
+    /** Timestamp at which this channel was last edited. */
+    editedTimestamp: Date | null;
     /** Timestamp (unix epoch time) that the forum thread was bumped at. */
     bumpedAt: string | null;
     /** Content of the thread */
@@ -42,10 +42,10 @@ export class ForumThread extends Base {
         this.guildID = data.serverId;
         this.channelID = data.channelId;
         this.name = data.title;
-        this._createdAt = Date.parse(data.createdAt);
+        this.createdAt = new Date(data.createdAt);
         this.ownerID = data.createdBy;
         this.webhookID = data.createdByWebhookId ?? null;
-        this._updatedAt = data.updatedAt ? Date.parse(data.updatedAt) : null;
+        this.editedTimestamp = data.updatedAt ? new Date(data.updatedAt) : null;
         this.bumpedAt = data.bumpedAt ?? null;
         this.content = data.content;
         this.mentions = data.mentions ?? null;
@@ -79,17 +79,7 @@ export class ForumThread extends Base {
         return this.client.rest.channels.getChannel(this.channelID);
     }
 
-    /** string representation of the _createdAt timestamp. */
-    get createdAt(): Date {
-        return new Date(this._createdAt);
-    }
-
-    /** string representation of the _updatedAt timestamp. */
-    get updatedAt(): Date|null {
-        return this._updatedAt ? new Date(this._updatedAt) : null;
-    }
-
-    /** Boolean that tells you if the forum thread was created by a webhook or not. */
+    /** If true, this forum thread was created by a webhook. */
     get createdByWebhook(): boolean {
         return this.webhookID ? true : false;
     }

--- a/lib/structures/ForumThreadComment.ts
+++ b/lib/structures/ForumThreadComment.ts
@@ -16,8 +16,8 @@ export class ForumThreadComment extends Base {
     updatedAt?: string;
     /** The ID of the forum thread */
     threadID: number;
-    /** The ID of the owner of this forum thread comment */
-    ownerID: string;
+    /** The ID of the user who sent this comment. */
+    memberID: string;
     /** ID of the forum thread's server, if provided. */
     guildID: string | null;
     /** ID of the forum channel containing this thread. */
@@ -30,21 +30,21 @@ export class ForumThreadComment extends Base {
         this.updatedAt = data.updatedAt;
         this.channelID = data.channelId;
         this.threadID = data.forumTopicId;
-        this.ownerID = data.createdBy;
+        this.memberID = data.createdBy;
         this.guildID = options?.guildID ?? null;
     }
 
-    /** Retrieve the thread comment's owner, if cached.
+    /** Retrieve the member who sent this comment, if cached.
      * If there is no cached member or user, this will make a request which returns a Promise.
      * If the request fails, this will throw an error or return you undefined as a value.
      */
-    get owner(): Member | User | Promise<Member> | undefined {
-        if (this.client.cache.members.get(this.ownerID) && this.ownerID){
-            return this.client.cache.members.get(this.ownerID);
-        } else if (this.client.cache.users.get(this.ownerID) && this.ownerID){
-            return this.client.cache.users.get(this.ownerID);
-        } else if (this.ownerID && this.guildID){
-            return this.client.rest.guilds.getMember(this.guildID, this.ownerID);
+    get member(): Member | User | Promise<Member> | undefined {
+        if (this.client.cache.members.get(this.memberID) && this.memberID){
+            return this.client.cache.members.get(this.memberID);
+        } else if (this.client.cache.users.get(this.memberID) && this.memberID){
+            return this.client.cache.users.get(this.memberID);
+        } else if (this.memberID && this.guildID){
+            return this.client.rest.guilds.getMember(this.guildID, this.memberID);
         }
     }
 

--- a/lib/structures/Guild.ts
+++ b/lib/structures/Guild.ts
@@ -2,6 +2,8 @@
 import { Client } from "./Client";
 import { Base } from "./Base";
 import { Channel } from "./Channel";
+import { Member } from "./Member";
+import { User } from "./User";
 import { APIGuild } from "../Constants";
 
 /** Represents a Guild, also called server. */
@@ -10,13 +12,11 @@ export class Guild extends Base {
     ownerID: string;
     /** Guild type. */
     type?: string;
-    /** Guild name. */
+    /** The name of the guild. */
     name: string;
-    /** Guild URL. */
+    /** The URL of the guild. */
     url?: string;
-    /** Guild's about/description. */
-    about?: string;
-    /** Guild's about/description. */
+    /** Guild description. */
     description?: string;
     /** Guild icon URL. */
     iconURL?: string | null;
@@ -39,8 +39,7 @@ export class Guild extends Base {
         this.type = data.type;
         this.name = data.name;
         this.url = data.url;
-        this.about = data.about; // same but with
-        this.description = data.about; //   two types.
+        this.description = data.about;
         this.iconURL = data.avatar ?? null;
         this.bannerURL = data.banner ?? null;
         this.timezone = data.timezone;
@@ -51,6 +50,20 @@ export class Guild extends Base {
     /** Date of the guild's creation. */
     get createdAt(): Date{
         return new Date(this._createdAt);
+    }
+
+    /** Retrieve guild's owner, if cached.
+     * If there is no cached member or user, this will make a request which returns a Promise.
+     * If the request fails, this will throw an error or return you undefined as a value.
+     */
+    get owner(): Member | User | Promise<Member> | undefined {
+        if (this.client.cache.members.get(this.ownerID) && this.ownerID){
+            return this.client.cache.members.get(this.ownerID);
+        } else if (this.client.cache.users.get(this.ownerID) && this.ownerID){
+            return this.client.cache.users.get(this.ownerID);
+        } else if (this.ownerID && this.id){
+            return this.client.rest.guilds.getMember(this.id as string, this.ownerID);
+        }
     }
 
     /** Get a channel from this guild.

--- a/lib/structures/Guild.ts
+++ b/lib/structures/Guild.ts
@@ -26,8 +26,8 @@ export class Guild extends Base {
     timezone?: string;
     /** Default channel of the guild. */
     defaultChannelID?: string;
-    /** Timestamp of the guild's creation. */
-    _createdAt: number;
+    /** When this guild was created. */
+    createdAt: Date;
 
     /**
      * @param data raw data.
@@ -44,12 +44,7 @@ export class Guild extends Base {
         this.bannerURL = data.banner ?? null;
         this.timezone = data.timezone;
         this.defaultChannelID = data.defaultChannelId;
-        this._createdAt = Date.parse(data.createdAt);
-    }
-
-    /** Date of the guild's creation. */
-    get createdAt(): Date{
-        return new Date(this._createdAt);
+        this.createdAt = new Date(data.createdAt);
     }
 
     /** Retrieve guild's owner, if cached.

--- a/lib/structures/ListItem.ts
+++ b/lib/structures/ListItem.ts
@@ -68,7 +68,7 @@ export class ListItem extends Base {
     }
 
     /** Retrieve the member who executed this action.
-     * Note: If the item has been edited, the updatedAt id will be used to get you the member.
+     * Note: If the item has been edited, the updatedBy id will be used to get you the member.
      */
     get member(): Member | User | Promise<Member> | undefined {
         if (this.client.cache.members.get(this.updatedBy ?? this.memberID)){

--- a/lib/structures/ListItem.ts
+++ b/lib/structures/ListItem.ts
@@ -18,20 +18,20 @@ export class ListItem extends Base {
     /** Content of the doc */
     content: string;
     mentions: APIMentions | null;
-    /** Timestamp (unix epoch time) of the list item's creation. */
-    _createdAt: number | null;
+    /** When the item was created. */
+    createdAt: Date | null;
     /** ID of the member who created the doc. */
     memberID: string;
     /** ID of the webhook that created the list item (if it was created by a webhook) */
     webhookID: string | null;
-    /** Timestamp (unix epoch time) of when the item was updated. (if updated) */
-    _updatedAt: number | null;
+    /** Timestamp at which the item was updated. */
+    editedTimestamp: Date | null;
     /** ID of the member who updated the doc. (if updated) */
     updatedBy: string | null;
     /** The ID of the parent list item if this list item is nested */
     parentListItemID: string | null;
-    /** Timestamp (unix epoch time) of the list item completion */
-    _completedAt: number | null;
+    /** When the list item was marked as "completed". */
+    completedAt: Date | null;
     /** ID of the member that completed the item, if completed. */
     completedBy: string | null;
 
@@ -46,24 +46,24 @@ export class ListItem extends Base {
         this.channelID = data.channelId;
         this.content = data.message ?? null;
         this.mentions = data.mentions ??  null;
-        this._createdAt = data.createdAt ? Date.parse(data.createdAt) : null;
+        this.createdAt = data.createdAt ? new Date(data.createdAt) : null;
         this.memberID = data.createdBy;
         this.webhookID = data.createdByWebhookId ?? null;
-        this._updatedAt = data.updatedAt ? Date.parse(data.updatedAt) : null;
+        this.editedTimestamp = data.updatedAt ? new Date(data.updatedAt) : null;
         this.updatedBy = data.updatedBy ?? null;
         this.parentListItemID = data.parentListItemId ?? null;
-        this._completedAt = data.completedAt ? Date.parse(data.completedAt) : null;
+        this.completedAt = data.completedAt ? new Date(data.completedAt) : null;
         this.completedBy = data.completedBy ?? null;
     }
 
     get note(): ListItemNoteTypes | null {
         return this._data.note ? {
-            createdAt: this._data.note.createdAt ? Date.parse(this._data.note.createdAt) : null,
-            createdBy: this._data.note.createdBy,
-            updatedAt: this._data.note.updatedAt ? Date.parse(this._data.note.updatedAt) : null,
-            updatedBy: this._data.note.updatedBy ?? null,
-            mentions:  this._data.note.mentions ?? null,
-            content:   this._data.note.content
+            createdAt:       new Date(this._data.note.createdAt),
+            memberID:        this._data.note.createdBy,
+            editedTimestamp: this._data.note.updatedAt ? new Date(this._data.note.updatedAt) : null,
+            editedBy:        this._data.note.updatedBy ?? null,
+            mentions:        this._data.note.mentions ?? null,
+            content:         this._data.note.content
         } as ListItemNoteTypes : null;
     }
 
@@ -78,21 +78,6 @@ export class ListItem extends Base {
         } else if (this.guildID){
             return this.client.rest.guilds.getMember(this.guildID, this.updatedBy ?? this.memberID);
         } else throw new Error("ERROR: Couldn't get member, failed to retrieve member.");
-    }
-
-    /** Date of the item's creation. */
-    get createdAt(): Date | null {
-        return this._createdAt ? new Date(this._createdAt) : null;
-    }
-
-    /** Date of the last item's edition, if updated. */
-    get updatedAt(): Date | null {
-        return this._updatedAt ? new Date(this._updatedAt) : null;
-    }
-
-    /** Date of the item's completion, if completed. */
-    get completedAt(): Date | null {
-        return this._completedAt ? new Date(this._completedAt) : null;
     }
 
     /** Edit this item.

--- a/lib/structures/Member.ts
+++ b/lib/structures/Member.ts
@@ -7,8 +7,8 @@ import { APIGuildMember } from "../Constants";
 
 /** Represents a guild user. */
 export class Member extends User {
-    /** Timestamp (unix epoch time) of when the member joined the server. */
-    _joinedAt: number | null;
+    /** When this member joined the guild. */
+    joinedAt: Date | null;
     /** Array of member's roles. */
     roles: Array<number>;
     /** Member's server nickname. */
@@ -28,7 +28,7 @@ export class Member extends User {
         this._data = data;
         this.roles = data.roleIds ?? null;
         this.nickname = data.nickname ?? null;
-        this._joinedAt = data.joinedAt ? Date.parse(data.joinedAt) : null;
+        this.joinedAt = data.joinedAt ? new Date(data.joinedAt) : null;
         this.isOwner = data.isOwner ?? false;
         this.guildID = guildID;
     }
@@ -38,11 +38,6 @@ export class Member extends User {
      */
     get guild(): Guild | Promise<Guild> {
         return this.client.cache.guilds.get(this.guildID) ?? this.client.rest.guilds.getGuild(this.guildID);
-    }
-
-    /** String representation of the _joinedAt timestamp. */
-    get joinedAt(): Date|number|null{
-        return this._joinedAt ? new Date(this._joinedAt) : null;
     }
 
     /** Member's user, shows less information. */

--- a/lib/structures/Message.ts
+++ b/lib/structures/Message.ts
@@ -36,12 +36,12 @@ export class Message extends Base {
     /** ID of the webhook used to send this message. (if sent by a webhook) */
     webhookID?: string|null;
 
-    /** Timestamp (unix epoch time) of the message's creation. */
-    readonly _createdAt: number;
-    /** Timestamp (unix epoch time) of the last message update/edition. */
-    readonly _updatedAt: number | null;
-    /** Timestamp (unix epoch time) of the message's deletion. */
-    readonly _deletedAt: number | null;
+    /** When the message was created. */
+    createdAt: Date;
+    /** Timestamp at which this message was last edited. */
+    editedTimestamp: Date | null;
+    /** When the message was deleted. */
+    deletedAt: Date | null;
 
     /** ID of the last message created with the message itself. */
     _lastMessageID: string | null;
@@ -61,31 +61,16 @@ export class Message extends Base {
         this.isPrivate = data.isPrivate ?? false;
         this.isSilent = data.isSilent ?? false;
         this.mentions = data.mentions as APIMentions ?? null;
-        this._createdAt = Date.parse(data.createdAt);
-        this._updatedAt = data.updatedAt ? Date.parse(data.updatedAt) : null;
+        this.createdAt = new Date(data.createdAt);
+        this.editedTimestamp = data.updatedAt ? new Date(data.updatedAt) : null;
         this.memberID = data.createdBy;
         this.webhookID = data.createdByWebhookId ?? null;
-        this._deletedAt = data["deletedAt" as keyof object] ? Date.parse(data["deletedAt" as keyof object]) : null;
+        this.deletedAt = data["deletedAt" as keyof object] ? new Date(data["deletedAt" as keyof object]) : null;
         this._lastMessageID = null;
         this.#originalMessageID = params?.originalMessageID ?? null;
         this.#originalMessageBool = false;
         this.oldContent = params?.oldMessage?.["content" as keyof object] ?? null; // taken from cache.
         void this.setCache.bind(this)();
-    }
-
-    /** string representation of the _createdAt timestamp. */
-    get createdAt(): Date{
-        return new Date(this._createdAt);
-    }
-
-    /** string representation of the _updatedAt timestamp. */
-    get updatedAt(): Date|void{
-        return this._updatedAt !== null ? new Date(this._updatedAt) : undefined;
-    }
-
-    /** string representation of the _deletedAt timestamp. */
-    get deletedAt(): Date|void{
-        return this._deletedAt !== null ? new Date(this._deletedAt) : undefined;
     }
 
     /** Retrieve message's member, if cached.

--- a/lib/structures/User.ts
+++ b/lib/structures/User.ts
@@ -13,9 +13,9 @@ export class User extends Base {
     avatarURL: string | null;
     /** Current banned url of the user. */
     bannerURL: string | null;
-    /** Timestamp (unix epoch time) of the user's account creation. */
-    _createdAt: number; // user
-    /** If set to true, the user is a bot. */
+    /** When the user account was created. */
+    createdAt: Date; // user
+    /** If true, the user is a bot. */
     bot: boolean;
 
     /**
@@ -26,16 +26,11 @@ export class User extends Base {
         super(data.id, client);
         this.type = data.type ?? null;
         this.username = data.name;
-        this._createdAt = Date.parse(data.createdAt);
+        this.createdAt = new Date(data.createdAt);
         this.avatarURL = data.avatar ?? null;
         this.bannerURL = data.banner ?? null;
 
         if (!this.type) this.type = "user"; // since it's only defined when it's a bot.
         this.bot = this.type === "bot" ? true : false;
-    }
-
-    /** Date of the user's account creation. */
-    get createdAt(): Date{
-        return new Date(this._createdAt);
     }
 }

--- a/lib/structures/UserClient.ts
+++ b/lib/structures/UserClient.ts
@@ -11,10 +11,10 @@ export class UserClient extends Base {
     type: string;
     /** User's name */
     username: string;
-    /** Timestamp (unix epoch time) of the user's creation. */
-    _createdAt: number; // user
+    /** When the bot client was created. */
+    createdAt: Date;
     /** ID of the bot's owner. */
-    createdBy: string;
+    ownerID: string;
     /**
      * @param data raw data.
      * @param client client.
@@ -24,8 +24,8 @@ export class UserClient extends Base {
         this.botID = data.botId;
         this.type = "bot";
         this.username = data.name;
-        this._createdAt = Date.parse(data.createdAt);
-        this.createdBy = data.createdBy;
+        this.createdAt = new Date(data.createdAt);
+        this.ownerID = data.createdBy;
     }
 
     /** Boolean that shows if the user is a bot or not.
@@ -33,10 +33,5 @@ export class UserClient extends Base {
      */
     get bot(): true {
         return true;
-    }
-
-    /** Date-time string of the bot's creation. */
-    get createdAt(): Date{
-        return new Date(this._createdAt);
     }
 }

--- a/lib/structures/Webhook.ts
+++ b/lib/structures/Webhook.ts
@@ -12,12 +12,12 @@ export class Webhook extends Base {
     channelID: string;
     /** Username of the webhook. */
     username: string;
-    /** Timestamp of the webhook's creation. */
-    _createdAt: number;
+    /** When the webhook was created. */
+    createdAt: Date;
     /** ID of the webhook's owner. */
-    createdBy: string;
-    /** Timestamp of the webhook's deletion, if deleted. */
-    _deletedAt: number | null;
+    ownerID: string;
+    /** When the webhook was deleted. */
+    deletedAt: Date | null;
     /** Token of the webhook. */
     token: string | null;
 
@@ -30,20 +30,10 @@ export class Webhook extends Base {
         this.guildID = data.serverId;
         this.channelID = data.channelId;
         this.username = data.name;
-        this._createdAt = Date.parse(data.createdAt);
-        this._deletedAt = data.deletedAt ? Date.parse(data.deletedAt) : null;
-        this.createdBy = data.createdBy;
+        this.createdAt = new Date(data.createdAt);
+        this.deletedAt = data.deletedAt ? new Date(data.deletedAt) : null;
+        this.ownerID = data.createdBy;
         this.token = data.token ?? null;
-    }
-
-    /** Date of the webhook's creation. */
-    get createdAt(): Date{
-        return new Date(this._createdAt);
-    }
-
-    /** Date of the webhook's deletion, if deleted. */
-    get deletedAt(): Date|null{
-        return this._deletedAt ? new Date(this._deletedAt) : null;
     }
 
     /** Update the webhook. */

--- a/lib/types/events.d.ts
+++ b/lib/types/events.d.ts
@@ -1,4 +1,4 @@
-import type { AnyReactionInfo } from "./types";
+import type { AnyReactionInfo, GuildCreateInfo } from "./types";
 import type { BannedMember } from "../structures/BannedMember";
 import type { ForumThread } from "../structures/ForumThread";
 import type { ForumThreadComment } from "../structures/ForumThreadComment";
@@ -6,6 +6,12 @@ import type { Message } from "../structures/Message";
 import type { Channel } from "../structures/Channel";
 import type { MemberRemoveInfo } from "../structures/MemberRemoveInfo";
 import type { MemberUpdateInfo } from "../structures/MemberUpdateInfo";
+import type { ListItem } from "../structures/ListItem";
+import type { CalendarEventRSVP } from "../structures/CalendarRSVP";
+import type { CalendarEvent } from "../structures/CalendarEvent";
+import type { Doc } from "../structures/Doc";
+import type { Member } from "../structures/Member";
+import type { Webhook } from "../structures/Webhook";
 
 export interface ClientEvents {
     // message: [message: string];
@@ -84,19 +90,19 @@ export interface ClientEvents {
     /** @event Emitted when an event RSVP is deleted. */
     calendarEventRsvpDelete: [CalendarRSVP: CalendarEventRSVP];
     /** @event Emitted when a list item is created. */
-    listItemCreate: [ListItem: ListItem];
+    listItemCreate: [item: ListItem];
     /** @event Emitted when a list item is edited. */
-    listItemUpdate: [ListItem: ListItem];
+    listItemUpdate: [item: ListItem];
     /** @event Emitted when a list item is deleted. */
-    listItemDelete: [ListItem: ListItem];
+    listItemDelete: [item: ListItem];
     /** @event Emitted when a list item is completed. */
-    listItemComplete: [ListItem: ListItem];
+    listItemComplete: [item: ListItem];
     /** @event Emitted when a list item is uncompleted. */
-    listItemUncomplete: [ListItem: ListItem];
+    listItemUncomplete: [item: ListItem];
     /** @event Emitted when a webhook got created. */
-    webhooksCreate: [Webhook: Webhook];
+    webhooksCreate: [webhook: Webhook];
     /** @event Emitted when a webhook is deleted. */
-    webhooksUpdate: [Webhook: Webhook];
+    webhooksUpdate: [webhook: Webhook];
     /** @event Emitted on process exit. */
     exit: [message: string];
 }

--- a/lib/types/types.d.ts
+++ b/lib/types/types.d.ts
@@ -35,6 +35,7 @@ export interface forumThreadReactionInfo {
     };
 }
 
+// deprecated.
 export interface UserClientTypes {
     user: {
         id: string;
@@ -46,11 +47,17 @@ export interface UserClientTypes {
 }
 
 export interface ListItemNoteTypes {
-    createdAt: number;
-    createdBy: string;
-    updatedAt?: number;
-    updatedBy?: string;
-    mentions?: APIMentions;
+    /** Date of the note's creation. */
+    createdAt: Date;
+    /** ID of the member who created this note. */
+    memberID: string;
+    /** Date of the note's last edition, if edited. */
+    editedTimestamp: null | Date;
+    /** ID of the member who edited this note, if edited. */
+    editedBy: null | string;
+    /** The mentions in this note. */
+    mentions: null | APIMentions;
+    /** The content of the note. */
     content: string;
 }
 
@@ -62,8 +69,8 @@ export interface GetSocialLink {
 
 export interface GuildCreateInfo {
     guild: Guild;
-    /** The ID of the user who created this server membership */
-    createdBy: string;
+    /** The ID of the member who invited the bot to the guild. */
+    inviterID: string;
 }
 
 export type AnyReactionInfo = MessageReactionInfo | ForumThreadReactionInfo;


### PR DESCRIPTION
* Fixed imports for `ClientEvents`.

* Deprecate `createdby` in favor of `inviterID` (`GuildCreateInfo`)

* Deprecate `BannedMember.ban.createdBy` in favor of `BannedMember.ban.bannedBy`

* Deprecate `CalendarEvent.memberID` in favor of `CalendarEvent.ownerID`

* Deprecate `CalendarEvent.member` in favor of `CalendarEvent.owner`.

* Deprecate `CalendarRSVP.memberID` in favor of `CalendarRSVP.entityID`.

* Deprecate `CalendarRSVP.createdBy` in favor of `CalendarRSVP.creatorID`

* Deprecate  `Channel.memberID` in favor of `Channel.creatorID`

* Deprecate `Channel.updatedAt` in favor `Channel.editedTimestamp`

* Deprecate `Doc.title` in favor of `Doc.name`

* Deprecate `Doc.updatedAt` in favor of `Doc.editedTimestamp`

* Deprecate `ForumThread.updatedAt` in favor `ForumThread.editedTimestamp`

* Deprecated `ForumThreadComment.createdBy` in favor of `ForumThreadComment.memberID`

* Deprecate `ForumThreadComment.owner` in favor of `ForumThreadComment.member`

* Deprecate `ListItem.updatedAt` in favor of `ListItem.editedTimestamp`

* `ListItemNoteTypes` changed: createdBy => memberID
updatedAt => editedTimestamp

* Deprecated `Guild.about` in favor of `Guild.description`

* `ForumThread.member` has been deprecated in favor of `ForumThread.owner`

* `ForumThread.memberID` has been deprecated in favor of `ForumThread.ownerID`

* Deprecating `ForumThread.title`, in favor of `ForumThread.name`

* Every structures doesn't include raw timestamps anymore.
