### PR TITLE
getters: removing requests when uncached.

### DIFF
--- a/lib/structures/BannedMember.ts
+++ b/lib/structures/BannedMember.ts
@@ -3,10 +3,11 @@ import { Client } from "./Client";
 import { User } from "./User";
 import { Guild } from "./Guild";
 import { APIGuildMemberBan, APIUser } from "../Constants";
+import { Uncached } from "../types/types";
 
 /** BannedMember represents a banned guild member. */
 export class BannedMember extends User {
-    /** Server ID. */
+    /** Guild ID. */
     guildID: string;
     /** Information about the banned member (object) */
     ban: {
@@ -32,11 +33,8 @@ export class BannedMember extends User {
         };
     }
 
-    /** Getter used to get the message's guild
-     *
-     * Note: this can return a promise, make sure to await it before.
-     */
-    get guild(): Guild | Promise<Guild> {
-        return this.client.cache.guilds.get(this.guildID) ?? this.client.rest.guilds.getGuild(this.guildID);
+    /** Banned member's guild, if cached. */
+    get guild(): Guild | Uncached {
+        return this.client.cache.guilds.get(this.guildID) ?? { id: this.guildID };
     }
 }

--- a/lib/structures/ForumThread.ts
+++ b/lib/structures/ForumThread.ts
@@ -9,6 +9,7 @@ import { ForumThreadComment } from "./ForumThreadComment";
 import { APIForumTopic, APIMentions } from "../Constants";
 import { EditForumThreadOptions } from "../types/forumThread";
 import { CreateForumCommentOptions } from "../types/forumThreadComment";
+import { Uncached } from "../types/types";
 
 /** Represents a thread/topic coming from a "Forums" channel. */
 export class ForumThread extends Base {
@@ -51,11 +52,9 @@ export class ForumThread extends Base {
         this.mentions = data.mentions ?? null;
     }
 
-    /** Guild where this thread's owner comes from, returns Guild or a promise.
-     * If guild isn't cached & the request failed, this will return you undefined.
-     */
-    get guild(): Guild | Promise<Guild> {
-        return this.client.cache.guilds.get(this.guildID) ?? this.client.rest.guilds.getGuild(this.guildID);
+    /** Guild where this thread's owner comes from, if cached. */
+    get guild(): Guild | Uncached {
+        return this.client.cache.guilds.get(this.guildID) ?? { id: this.guildID };
     }
 
     /** Retrieve thread's owner, if cached.

--- a/lib/structures/ForumThreadComment.ts
+++ b/lib/structures/ForumThreadComment.ts
@@ -18,6 +18,8 @@ export class ForumThreadComment extends Base {
     updatedAt?: string;
     /** The ID of the forum thread */
     threadID: number;
+    /** The ID of the user who sent this comment. */
+    memberID: string;
     /** ID of the forum thread's server, if provided. */
     guildID: string | null;
     /** ID of the forum channel containing this thread. */
@@ -33,6 +35,7 @@ export class ForumThreadComment extends Base {
         this.updatedAt = data.updatedAt;
         this.channelID = data.channelId;
         this.threadID = data.forumTopicId;
+        this.memberID = data.createdBy;
         this.guildID = options?.guildID ?? null;
         this.mentions = data.mentions ?? null;
     }

--- a/lib/structures/ForumThreadReactionInfo.ts
+++ b/lib/structures/ForumThreadReactionInfo.ts
@@ -1,7 +1,7 @@
 /** @module ForumThreadReactionInfo */
 import { ReactionInfo } from "./ReactionInfo";
 import { Client } from "./Client";
-import { forumThreadReactionInfo } from "../types/types";
+import { ForumThreadReactionTypes } from "../types/types";
 import { GatewayEvent_ForumTopicReactionCreated, GatewayEvent_ForumTopicReactionDeleted } from "../Constants";
 
 /** Information about a ForumThread's reaction. */
@@ -20,7 +20,7 @@ export class ForumThreadReactionInfo extends ReactionInfo {
      * If the thread is cached, it'll return a ForumThread component,
      * otherwise it'll return basic information about this thread.
      */
-    get thread(): forumThreadReactionInfo["thread"] {
+    get thread(): ForumThreadReactionTypes["thread"] {
         return this.client.cache.forumThreads.get(this.#threadID) ?? {
             id:    this.#threadID,
             guild: this.client.cache.guilds.get(this.data.serverId as string) ?? {

--- a/lib/structures/Member.ts
+++ b/lib/structures/Member.ts
@@ -3,7 +3,7 @@ import { Client } from "./Client";
 import { User } from "./User";
 import { Guild } from "./Guild";
 import { BannedMember } from "./BannedMember";
-import { GetSocialLink } from "../types/types";
+import { GetSocialLink, Uncached } from "../types/types";
 import { APIGuildMember } from "../Constants";
 import { EditMemberOptions } from "../types/guilds";
 
@@ -38,12 +38,12 @@ export class Member extends User {
     /** Guild where the user comes from, returns Guild or a promise.
      * If guild isn't cached & the request failed, this will return you undefined.
      */
-    get guild(): Guild | Promise<Guild> {
-        return this.client.cache.guilds.get(this.guildID) ?? this.client.rest.guilds.getGuild(this.guildID);
+    get guild(): Guild | Uncached {
+        return this.client.cache.guilds.get(this.guildID) ?? { id: this.guildID };
     }
 
     /** Member's user, shows less information. */
-    get user(): User{
+    get user(): User {
         return new User(this._data.user, this.client);
     }
 

--- a/lib/structures/MemberInfo.ts
+++ b/lib/structures/MemberInfo.ts
@@ -3,6 +3,7 @@ import type { Client } from "./Client";
 import type { Guild } from "./Guild";
 import type { Member } from "./Member";
 import type { GatewayEvent_ServerMemberUpdated as GWMUpdated, GatewayEvent_ServerRolesUpdated as GWMRolesUpdated, GatewayEvent_ServerMemberRemoved as GWMRemoved } from "../Constants";
+import { Uncached } from "../types/types";
 
 /** Base class for member information classes. */
 export abstract class MemberInfo {
@@ -18,11 +19,13 @@ export abstract class MemberInfo {
         this.memberID = memberID;
     }
 
-    get guild(): Guild | Promise<Guild> {
-        return this.client!.cache.guilds.get(this.guildID) ?? this.client!.rest.guilds.getGuild(this.guildID);
+    /** Retrieve guild, if cached. */
+    get guild(): Guild | Uncached {
+        return this.client!.cache.guilds.get(this.guildID) ?? { id: this.guildID };
     }
 
-    get member(): Member | Promise<Member> {
-        return this.client!.cache.members.get(this.memberID) ?? this.client!.rest.guilds.getMember(this.guildID, this.memberID);
+    /** Retrieve member, if cached. */
+    get member(): Member | Uncached {
+        return this.client!.cache.members.get(this.memberID) ?? { id: this.memberID };
     }
 }

--- a/lib/structures/Message.ts
+++ b/lib/structures/Message.ts
@@ -81,7 +81,7 @@ export class Message extends Base {
         return this.client.cache.guilds.get(this.guildID) ?? { id: this.guildID };
     }
 
-    /** Getter used to get the message's channel
+    /** Channel where the message was sent.
      *
      * Note: this returns a promise, make sure to await it before.
      */

--- a/lib/structures/MessageReactionInfo.ts
+++ b/lib/structures/MessageReactionInfo.ts
@@ -1,7 +1,7 @@
 /** @module MessageReactionInfo */
 import { ReactionInfo } from "./ReactionInfo";
 import { Client } from "../structures/Client";
-import { messageReactionInfo } from "../types/types";
+import { MessageReactionTypes } from "../types/types";
 import { GatewayEvent_ChannelMessageReactionAdded, GatewayEvent_ChannelMessageReactionDeleted } from "../Constants";
 
 /** Information about a Message's reaction. */
@@ -20,7 +20,7 @@ export class MessageReactionInfo extends ReactionInfo {
      * If the message is cached, it'll return a Message component,
      * otherwise it'll return basic information about this message.
      */
-    get message(): messageReactionInfo["message"] {
+    get message(): MessageReactionTypes["message"] {
         return this.client.cache.messages.get(this.#messageID) ?? {
             id:    this.#messageID,
             guild: this.client.cache.guilds.get(this.data.serverId as string) ?? {

--- a/lib/types/types.d.ts
+++ b/lib/types/types.d.ts
@@ -7,7 +7,7 @@ import type { MessageReactionInfo } from "../structures/MessageReactionInfo";
 import type { ForumThreadReactionInfo } from "../structures/ForumThreadReactionInfo";
 import type { APIEmote, APIMentions } from "../Constants";
 
-export interface messageReactionInfo {
+export interface MessageReactionTypes {
     message: Message | {
         id: string;
         guild: Guild | {
@@ -21,7 +21,7 @@ export interface messageReactionInfo {
     };
 }
 
-export interface forumThreadReactionInfo {
+export interface ForumThreadReactionTypes {
     thread: ForumThread | {
         id: number;
         guild: Guild | {
@@ -35,7 +35,6 @@ export interface forumThreadReactionInfo {
     };
 }
 
-// deprecated.
 export interface UserClientTypes {
     /** Client's user. */
     user: {

--- a/lib/types/types.d.ts
+++ b/lib/types/types.d.ts
@@ -85,3 +85,4 @@ export interface GuildDeleteInfo {
 }
 
 export type AnyReactionInfo = MessageReactionInfo | ForumThreadReactionInfo;
+export interface Uncached { id: string | number; }


### PR DESCRIPTION
* Add `Uncached`
* `Message#member` doesn't return `Promise<Member>`, `User`, `undefined` anymore. It returns `Member` or `Uncached`.
* Deprecate `Doc#memberID` in favor of `Doc#creatorID`
* `Doc#member` doesn't return a promise anymore.
* `ForumThreadComment#member` doesn't return promise anymore.
* `ListItem#member` doesn't return promise anymore.
* Deprecate `ListItem#memberID` in favor of `ListItem#creatorID`
* `MemberInfo#member` and `MemberInfo#guild` doesn't return promise anymore.
* `Member#guild` doesn't return promise when uncached anymore.
* `ForumThread#guild` doesn't return promise when uncached anymore.
* `BannedMember#guild` doesn't return promise when uncached anymore.
* Deprecate `messageReactionInfo` in favor of `MessageReactionTypes`
* Deprecate `forumThreadReactionInfo` in favor of `ForumThreadReactionTypes`