### PR TITLE
Major cache update, cache hierarchy.

### DIFF
--- a/lib/gateway/GatewayHandler.ts
+++ b/lib/gateway/GatewayHandler.ts
@@ -124,8 +124,13 @@ export class GatewayHandler {
         ListItemUncompleted:           data => this.listItemHandler.listItemUncomplete(data as GatewayEvent_ListItemUncompleted)
     };
 
-    handleMessage(eventType: keyof GATEWAY_EVENTS, eventData: object): void {
+    async handleMessage(eventType: keyof GATEWAY_EVENTS, eventData: object): Promise<void> {
         if (this.client.identifiers[eventType as keyof object]){
+            const serverId = "serverId" as keyof object;
+            if (eventData[serverId] && this.client.guilds.get(eventData[serverId]) === undefined) {
+                // eslint-disable-next-line @typescript-eslint/no-floating-promises
+                this.client.guilds.add(await this.client.rest.guilds.getGuild(eventData[serverId]));
+            }
             if (eventData["message" as keyof object] && eventData["message" as keyof object]["type" as keyof object] === "system") return; // system sending fake messages, haha :)
             this.toHandlerMap[eventType]?.(eventData);
         }

--- a/lib/gateway/events/CalendarHandler.ts
+++ b/lib/gateway/events/CalendarHandler.ts
@@ -9,35 +9,62 @@ import {
     GatewayEvent_CalendarEventRsvpUpdated,
     GatewayEvent_CalendarEventUpdated
 } from "../../Constants";
+import { CalendarChannel } from "../../structures/CalendarChannel";
 
 /** Internal component, emitting calendar events. */
-export class CalendarHandler extends GatewayEventHandler{
+export class CalendarHandler extends GatewayEventHandler {
     calendarEventCreate(data: GatewayEvent_CalendarEventCreated): void {
-        const CalendarEventComponent = new CalendarEvent(data.calendarEvent, this.client);
+        void this.addGuildChannel(data.serverId, data.calendarEvent.channelId);
+        const channel = this.client.getChannel<CalendarChannel>(data.serverId, data.calendarEvent.channelId);
+        const CalendarEventComponent = channel?.scheduledEvents.update(data.calendarEvent) ?? new CalendarEvent(data.calendarEvent, this.client);
         this.client.emit("calendarEventCreate", CalendarEventComponent);
     }
 
     calendarEventUpdate(data: GatewayEvent_CalendarEventUpdated): void {
-        const CalendarEventComponent = new CalendarEvent(data.calendarEvent, this.client);
+        void this.addGuildChannel(data.serverId, data.calendarEvent.channelId);
+        const channel = this.client.getChannel<CalendarChannel>(data.serverId, data.calendarEvent.channelId);
+        const CalendarEventComponent = channel?.scheduledEvents.update(data.calendarEvent) ?? new CalendarEvent(data.calendarEvent, this.client);
         this.client.emit("calendarEventUpdate", CalendarEventComponent);
     }
 
     calendarEventDelete(data: GatewayEvent_CalendarEventDeleted): void {
-        const CalendarEventComponent = new CalendarEvent(data.calendarEvent, this.client);
+        void this.addGuildChannel(data.serverId, data.calendarEvent.channelId);
+        const channel = this.client.getChannel<CalendarChannel>(data.serverId, data.calendarEvent.channelId);
+        const CalendarEventComponent = channel?.scheduledEvents.update(data.calendarEvent) ?? new CalendarEvent(data.calendarEvent, this.client);
+        channel?.scheduledEvents.delete(data.calendarEvent.id);
         this.client.emit("calendarEventDelete", CalendarEventComponent);
     }
 
     calendarRsvpUpdate(data: GatewayEvent_CalendarEventRsvpUpdated): void {
-        const CalendarERSVPComponent = new CalendarEventRSVP(data.calendarEventRsvp, this.client);
+        void this.addGuildChannel(data.calendarEventRsvp.serverId, data.calendarEventRsvp.channelId, data.calendarEventRsvp.calendarEventId);
+        const channel = this.client.getChannel<CalendarChannel>(data.calendarEventRsvp.serverId, data.calendarEventRsvp.channelId);
+        const updateFromCache = channel?.scheduledEvents.get(data.calendarEventRsvp.calendarEventId)?.rsvps.update(data.calendarEventRsvp);
+        const CalendarERSVPComponent = updateFromCache ?? new CalendarEventRSVP(data.calendarEventRsvp, this.client);
         this.client.emit("calendarEventRsvpUpdate", CalendarERSVPComponent);
     }
 
     calendarRsvpDelete(data: GatewayEvent_CalendarEventRsvpDeleted): void {
-        const CalendarERSVPComponent = new CalendarEventRSVP(data.calendarEventRsvp, this.client);
+        void this.addGuildChannel(data.calendarEventRsvp.serverId, data.calendarEventRsvp.channelId, data.calendarEventRsvp.calendarEventId);
+        const channel = this.client.getChannel<CalendarChannel>(data.calendarEventRsvp.serverId, data.calendarEventRsvp.channelId);
+        const updateFromCache = channel?.scheduledEvents.get(data.calendarEventRsvp.calendarEventId)?.rsvps.update(data.calendarEventRsvp);
+        const CalendarERSVPComponent = updateFromCache ?? new CalendarEventRSVP(data.calendarEventRsvp, this.client);
         this.client.emit("calendarEventRsvpDelete", CalendarERSVPComponent);
     }
 
     calendarRsvpManyUpdated(): void {
         return; // TouchGuild doesn't support many updated.
+    }
+
+    private async addGuildChannel(guildID: string, channelID: string, eventID?: number): Promise<void> {
+        const guild = this.client.guilds.get(guildID);
+        if (this.client.getChannel(guildID, channelID) === undefined) {
+            const channel = await this.client.rest.channels.getChannel(channelID);
+            guild?.channels?.add(channel);
+        }
+        const conditions = this.client.getChannel(guildID, channelID) !== undefined && this.client.getChannel<CalendarChannel>(guildID, channelID)?.scheduledEvents.get(eventID as number) === undefined;
+        if (guildID && channelID && eventID && conditions) {
+            const restEvent = await this.client.rest.channels.getCalendarEvent(channelID, eventID);
+            (guild?.channels.get(channelID) as CalendarChannel)?.scheduledEvents.add(restEvent);
+        }
     }
 }

--- a/lib/gateway/events/DocHandler.ts
+++ b/lib/gateway/events/DocHandler.ts
@@ -2,21 +2,36 @@
 import { GatewayEventHandler } from "./GatewayEventHandler";
 import { Doc } from "../../structures/Doc";
 import { GatewayEvent_DocCreated, GatewayEvent_DocDeleted, GatewayEvent_DocUpdated } from "../../Constants";
+import { DocChannel } from "../../structures/DocChannel";
 
 /** Internal component, emitting doc events. */
-export class DocHandler extends GatewayEventHandler{
+export class DocHandler extends GatewayEventHandler {
     docCreate(data: GatewayEvent_DocCreated): void {
-        const DocComponent = new Doc(data.doc, this.client);
+        void this.addGuildChannel(data.serverId, data.doc.channelId);
+        const channel = this.client.getChannel<DocChannel>(data.serverId, data.doc.channelId);
+        const DocComponent = channel?.docs.update(data.doc) ?? new Doc(data.doc, this.client);
         this.client.emit("docCreate", DocComponent);
     }
 
     docUpdate(data: GatewayEvent_DocUpdated): void {
-        const DocComponent = new Doc(data.doc, this.client);
+        void this.addGuildChannel(data.serverId, data.doc.channelId);
+        const channel = this.client.getChannel<DocChannel>(data.serverId, data.doc.channelId);
+        const DocComponent = channel?.docs.update(data.doc) ?? new Doc(data.doc, this.client);
         this.client.emit("docUpdate", DocComponent);
     }
 
     docDelete(data: GatewayEvent_DocDeleted): void {
-        const DocComponent = new Doc(data.doc, this.client);
+        void this.addGuildChannel(data.serverId, data.doc.channelId);
+        const channel = this.client.getChannel<DocChannel>(data.serverId, data.doc.channelId);
+        const DocComponent = channel?.docs.update(data.doc) ?? new Doc(data.doc, this.client);
+        channel?.docs.delete(data.doc.id);
         this.client.emit("docDelete", DocComponent);
+    }
+
+    private async addGuildChannel(guildID: string, channelID: string): Promise<void> {
+        if (this.client.getChannel(guildID, channelID) !== undefined) return;
+        const channel = await this.client.rest.channels.getChannel(channelID);
+        const guild = this.client.guilds.get(guildID);
+        guild?.channels?.add(channel);
     }
 }

--- a/lib/gateway/events/ForumThreadHandler.ts
+++ b/lib/gateway/events/ForumThreadHandler.ts
@@ -17,69 +17,122 @@ import {
     GatewayEvent_ForumTopicUnpinned,
     GatewayEvent_ForumTopicUpdated
 } from "../../Constants";
+import { ForumChannel } from "../../structures/ForumChannel";
 
 /** Internal component, emitting forum thread events. */
-export class ForumThreadHandler extends GatewayEventHandler{
+export class ForumThreadHandler extends GatewayEventHandler {
     forumThreadCreate(data: GatewayEvent_ForumTopicCreated): boolean {
-        const Thread = new ForumThread(data.forumTopic, this.client);
-        this.client.cache.forumThreads.add(Thread);
+        void this.addGuildChannel(data.serverId, data.forumTopic.channelId);
+        const channel = this.client.getChannel<ForumChannel>(data.serverId, data.forumTopic.channelId);
+        const Thread = channel?.threads?.update(data.forumTopic) ?? new ForumThread(data.forumTopic, this.client);
+        channel?.threads?.add(Thread);
         return this.client.emit("forumThreadCreate", Thread);
     }
 
     forumThreadUpdate(data: GatewayEvent_ForumTopicUpdated): boolean {
-        const Thread = new ForumThread(data.forumTopic, this.client);
-        this.client.cache.forumThreads.add(Thread);
+        void this.addGuildChannel(data.serverId, data.forumTopic.channelId);
+        const channel = this.client.getChannel<ForumChannel>(data.serverId, data.forumTopic.channelId);
+        const Thread = channel?.threads?.update(data.forumTopic) ?? new ForumThread(data.forumTopic, this.client);
         return this.client.emit("forumThreadUpdate", Thread);
     }
 
     forumThreadDelete(data: GatewayEvent_ForumTopicDeleted): boolean {
-        const Thread = new ForumThread(data.forumTopic, this.client);
-        this.client.cache.forumThreads.delete(Thread.id);
+        void this.addGuildChannel(data.serverId, data.forumTopic.channelId);
+        const channel = this.client.getChannel<ForumChannel>(data.serverId, data.forumTopic.channelId);
+        const Thread = channel?.threads?.update(data.forumTopic) ?? new ForumThread(data.forumTopic, this.client);
+        channel?.threads?.delete(Thread.id);
         return this.client.emit("forumThreadDelete", Thread);
     }
 
     forumThreadPin(data: GatewayEvent_ForumTopicPinned): boolean {
-        const Thread = new ForumThread(data.forumTopic, this.client);
+        void this.addGuildChannel(data.serverId, data.forumTopic.channelId);
+        const channel = this.client.getChannel<ForumChannel>(data.serverId, data.forumTopic.channelId);
+        const Thread = channel?.threads.update(data.forumTopic) ?? new ForumThread(data.forumTopic, this.client);
         return this.client.emit("forumThreadPin", Thread);
     }
 
     forumThreadUnpin(data: GatewayEvent_ForumTopicUnpinned): boolean {
-        const Thread = new ForumThread(data.forumTopic, this.client);
+        void this.addGuildChannel(data.serverId, data.forumTopic.channelId);
+        const channel = this.client.getChannel<ForumChannel>(data.serverId, data.forumTopic.channelId);
+        const Thread = channel?.threads.update(data.forumTopic) ?? new ForumThread(data.forumTopic, this.client);
         return this.client.emit("forumThreadUnpin", Thread);
     }
 
     forumThreadCommentCreate(data: GatewayEvent_ForumTopicCommentCreated): boolean {
-        const ThreadComment = new ForumThreadComment(data.forumTopicComment, this.client, { guildID: data.serverId });
+        void this.addGuildChannel(data.serverId, data.forumTopicComment.channelId, data.forumTopicComment.forumTopicId);
+        const channel = this.client.getChannel<ForumChannel>(data.serverId, data.forumTopicComment.channelId);
+        const cachedTC = channel?.threads.get(data.forumTopicComment.forumTopicId)?.comments.update(data.forumTopicComment);
+        const ThreadComment = cachedTC ?? new ForumThreadComment(data.forumTopicComment, this.client, { guildID: data.serverId });
+        channel?.threads?.get(data.forumTopicComment.forumTopicId)?.comments.add(ThreadComment);
         return this.client.emit("forumCommentCreate", ThreadComment);
     }
 
     forumThreadCommentUpdate(data: GatewayEvent_ForumTopicCommentUpdated): boolean {
-        const ThreadComment = new ForumThreadComment(data.forumTopicComment, this.client, { guildID: data.serverId });
+        void this.addGuildChannel(data.serverId, data.forumTopicComment.channelId, data.forumTopicComment.forumTopicId);
+        const channel = this.client.getChannel<ForumChannel>(data.serverId, data.forumTopicComment.channelId);
+        const cachedTC = channel?.threads.get(data.forumTopicComment.forumTopicId)?.comments.update(data.forumTopicComment);
+        const ThreadComment = cachedTC ?? new ForumThreadComment(data.forumTopicComment, this.client, { guildID: data.serverId });
         return this.client.emit("forumCommentUpdate", ThreadComment);
     }
 
     forumThreadCommentDelete(data: GatewayEvent_ForumTopicCommentDeleted): boolean {
-        const ThreadComment = new ForumThreadComment(data.forumTopicComment, this.client, { guildID: data.serverId });
+        void this.addGuildChannel(data.serverId, data.forumTopicComment.channelId, data.forumTopicComment.forumTopicId);
+        const channel = this.client.getChannel<ForumChannel>(data.serverId, data.forumTopicComment.channelId);
+        const cachedTC = channel?.threads.get(data.forumTopicComment.forumTopicId)?.comments.update(data.forumTopicComment);
+        const ThreadComment = cachedTC ?? new ForumThreadComment(data.forumTopicComment, this.client, { guildID: data.serverId });
+        channel?.threads?.get(data.forumTopicComment.forumTopicId)?.comments.delete(ThreadComment.id);
         return this.client.emit("forumCommentDelete", ThreadComment);
     }
 
     forumThreadLock(data: GatewayEvent_ForumTopicLocked): boolean {
-        const Thread = new ForumThread(data.forumTopic, this.client);
+        void this.addGuildChannel(data.forumTopic.serverId, data.forumTopic.channelId);
+        const channel = this.client.getChannel<ForumChannel>(data.forumTopic.serverId, data.forumTopic.channelId);
+        const Thread = channel?.threads.update(data.forumTopic) ?? new ForumThread(data.forumTopic, this.client);
         return this.client.emit("forumThreadLock", Thread);
     }
 
     forumThreadUnlock(data: GatewayEvent_ForumTopicUnlocked): boolean {
-        const Thread = new ForumThread(data.forumTopic, this.client);
+        void this.addGuildChannel(data.forumTopic.serverId, data.forumTopic.channelId);
+        const channel = this.client.getChannel<ForumChannel>(data.forumTopic.serverId, data.forumTopic.channelId);
+        const Thread = channel?.threads.update(data.forumTopic) ?? new ForumThread(data.forumTopic, this.client);
         return this.client.emit("forumThreadUnlock", Thread);
     }
 
     forumThreadReactionAdd(data: GatewayEvent_ForumTopicReactionCreated): boolean {
+        if (data.serverId) void this.addGuildChannel(data.serverId, data.reaction.channelId);
         const ReactionInfo = new ForumThreadReactionInfo(data, this.client);
         return this.client.emit("reactionAdd", ReactionInfo);
     }
 
     forumThreadReactionRemove(data: GatewayEvent_ForumTopicReactionDeleted): boolean {
+        if (data.serverId) void this.addGuildChannel(data.serverId, data.reaction.channelId);
         const ReactionInfo = new ForumThreadReactionInfo(data, this.client);
         return this.client.emit("reactionRemove", ReactionInfo);
     }
+
+    private async addGuildChannel(guildID: string, channelID: string, threadID?: number): Promise<void> {
+        const guild = this.client.guilds.get(guildID);
+        if (this.client.getChannel(guildID, channelID) === undefined) {
+            const channel = await this.client.rest.channels.getChannel(channelID);
+            guild?.channels?.add(channel);
+        }
+        const conditions = this.client.getChannel(guildID, channelID) !== undefined && this.client.getChannel<ForumChannel>(guildID, channelID)?.threads.get(threadID as number) === undefined;
+        console.log(conditions);
+        if (guildID && channelID && threadID && conditions) {
+            const restThread = await this.client.rest.channels.getForumThread(channelID, threadID as number);
+            const channel = guild?.channels.get(channelID) as ForumChannel;
+            channel?.threads.add(restThread);
+        }
+        // const guild = this.client.guilds.get(guildID);
+        // const restThread = await this.client.rest.channels.getForumThread(channelID, threadID as number);
+        // guild?.channels.get(channelID)?.threads?.add(restThread);
+    }
+
+    // private async addChannelThread(guildID: string, channelID: string, threadID: number): Promise<void> {
+    //     await this.addGuildChannel(guildID, channelID);
+    //     if (this.client.getChannel(guildID, channelID)?.threads.get(threadID) !== undefined) return;
+    //     const channel = this.client.guilds.get(guildID)?.channels.get(channelID);
+    //     const restThread = await this.client.rest.channels.getForumThread(channelID, threadID);
+    //     if (channel?.threads instanceof TypedCollection) channel.threads.add(channel.threads.update(restThread));
+    // }
 }

--- a/lib/gateway/events/GuildHandler.ts
+++ b/lib/gateway/events/GuildHandler.ts
@@ -18,7 +18,7 @@ import { MemberUpdateInfo } from "../../structures/MemberUpdateInfo";
 import { MemberRemoveInfo } from "../../structures/MemberRemoveInfo";
 
 /** Internal component, emitting guild events. */
-export class GuildHandler extends GatewayEventHandler{
+export class GuildHandler extends GatewayEventHandler {
     guildBanAdd(data: GatewayEvent_ServerMemberBanned): void{
         const GuildMemberBanComponent = new BannedMember(data.serverId, data.serverMemberBan, this.client);
         this.client.emit("guildBanAdd", GuildMemberBanComponent);
@@ -51,6 +51,7 @@ export class GuildHandler extends GatewayEventHandler{
 
     guildCreate(data: GatewayEvent_BotServerMembershipCreated): void{
         const GuildComponent = new Guild(data.server, this.client);
+        this.client.guilds.add(GuildComponent);
         const output = {
             guild:     GuildComponent,
             inviterID: data.createdBy
@@ -60,6 +61,7 @@ export class GuildHandler extends GatewayEventHandler{
 
     guildDelete(data: GatewayEvent_BotServerMembershipDeleted): void{
         const GuildComponent = new Guild(data.server, this.client);
+        this.client.guilds.delete(GuildComponent.id as string);
         const output = {
             guild:     GuildComponent,
             removerID: data.createdBy

--- a/lib/gateway/events/MessageHandler.ts
+++ b/lib/gateway/events/MessageHandler.ts
@@ -9,41 +9,55 @@ import {
     GatewayEvent_ChatMessageDeleted,
     GatewayEvent_ChatMessageUpdated
 } from "../../Constants";
+import { TextChannel } from "../../structures/TextChannel";
 
 /** Internal component, emitting message events. */
-export class MessageHandler extends GatewayEventHandler{
+export class MessageHandler extends GatewayEventHandler {
     messageCreate(data: GatewayEvent_ChatMessageCreated): boolean {
-        const MessageComponent = new Message(data.message, this.client);
-        this.client.cache.messages.add(MessageComponent);
+        void this.addGuildChannel(data.serverId, data.message.channelId);
+        const channel = this.client.getChannel<TextChannel>(data.serverId, data.message.channelId);
+        const MessageComponent = channel?.messages?.update(data.message) ?? new Message(data.message, this.client);
         return this.client.emit("messageCreate", MessageComponent);
     }
 
     messageUpdate(data: GatewayEvent_ChatMessageUpdated): boolean {
-        const MessageComponent = new Message(data.message, this.client);
-        const CachedMessage = this.client.cache.messages.get(data.message.id);
-        this.client.cache.messages.add(MessageComponent);
-        return this.client.emit("messageUpdate", MessageComponent, CachedMessage ?? null);
+        void this.addGuildChannel(data.serverId, data.message.channelId);
+        const channel = this.client.getChannel<TextChannel>(data.serverId, data.message.channelId);
+        const CachedMessage = channel?.messages?.get(data.message.id)?.toJSON() ?? null;
+        const MessageComponent = channel?.messages?.update(data.message) ?? new Message(data.message, this.client);
+        return this.client.emit("messageUpdate", MessageComponent, CachedMessage);
     }
 
     messageDelete(data: GatewayEvent_ChatMessageDeleted): boolean {
-        const PU_Message = this.client.cache.messages.get(data.message.id) ?? {
+        void this.addGuildChannel(data.serverId, data.message.channelId);
+        const channel = this.client.getChannel<TextChannel>(data.serverId, data.message.channelId);
+        const PU_Message = channel?.messages.update(data.message) ?? {
             id:        data.message.id,
             guildID:   data.serverId,
             channelID: data.message.channelId,
             deletedAt: new Date(data.message.deletedAt),
             isPrivate: data.message.isPrivate ?? null
         };
-        this.client.cache.messages.delete(data.message.id);
+        channel?.messages?.delete(data.message.id);
         return this.client.emit("messageDelete", PU_Message);
     }
 
     messageReactionAdd(data: GatewayEvent_ChannelMessageReactionAdded): boolean {
+        if (data.serverId) void this.addGuildChannel(data.serverId, data.reaction.channelId);
         const ReactionInfo = new MessageReactionInfo(data, this.client);
         return this.client.emit("reactionAdd", ReactionInfo);
     }
 
     messageReactionRemove(data: GatewayEvent_ChannelMessageReactionDeleted): boolean {
+        if (data.serverId) void this.addGuildChannel(data.serverId, data.reaction.channelId);
         const ReactionInfo = new MessageReactionInfo(data, this.client);
         return this.client.emit("reactionRemove", ReactionInfo);
+    }
+
+    private async addGuildChannel(guildID: string, channelID: string): Promise<void> {
+        if (this.client.getChannel(guildID, channelID) !== undefined) return;
+        const channel = await this.client.rest.channels.getChannel(channelID);
+        const guild = this.client.guilds.get(guildID);
+        guild?.channels?.add(channel);
     }
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -4,6 +4,11 @@ export * from "./structures/Client";
 export * from "./structures/User";
 export * from "./structures/Member";
 export * from "./structures/Channel";
+export * from "./structures/GuildChannel";
+export * from "./structures/DocChannel";
+export * from "./structures/TextChannel";
+export * from "./structures/ForumChannel";
+export * from "./structures/CalendarChannel";
 export * from "./structures/Guild";
 export * from "./structures/UserClient";
 

--- a/lib/routes/Guilds.ts
+++ b/lib/routes/Guilds.ts
@@ -26,7 +26,7 @@ import {
     GETGuildBanResponse,
     GETGuildBansResponse
 } from "../Constants";
-import { CreateChannelOptions, EditChannelOptions } from "../types/channel";
+import { AnyChannel, CreateChannelOptions, EditChannelOptions } from "../types/channel";
 import { EditWebhookOptions } from "../types/webhooks";
 import { EditMemberOptions } from "../types/guilds";
 import { BannedMember } from "../structures/BannedMember";
@@ -310,7 +310,7 @@ export class Guilds {
      * @param type Type of the new channel. (e.g: chat)
      * @param options New channel's additional options.
      */
-    async createChannel(guildID: string, name: string, type: APIChannelCategories, options?: CreateChannelOptions): Promise<Channel> {
+    async createChannel<T extends AnyChannel = AnyChannel>(guildID: string, name: string, type: APIChannelCategories, options?: CreateChannelOptions): Promise<T> {
         if (!guildID) throw new Error("guildID is a required parameter.");
         if (!name) throw new Error("name parameter is a required parameter.");
         if (!type) type = "chat";
@@ -327,14 +327,14 @@ export class Guilds {
                 groupId:    options?.groupID,
                 categoryId: options?.categoryID
             }
-        }).then(data => new Channel(data.channel, this.#manager.client));
+        }).then(data => Channel.from<T>(data.channel, this.#manager.client));
     }
 
     /** Edit a channel.
      * @param channelID ID of the channel to edit.
      * @param options Channel edit options.
      */
-    async editChannel(channelID: string, options: EditChannelOptions): Promise<Channel> {
+    async editChannel<T extends AnyChannel = AnyChannel>(channelID: string, options: EditChannelOptions): Promise<T> {
         if (!channelID) throw new Error("channelID is a required parameter.");
         return this.#manager.authRequest<PATCHChannelResponse>({
             method: "PATCH",
@@ -344,7 +344,7 @@ export class Guilds {
                 topic:    options.description,
                 isPublic: options.isPublic
             }
-        }).then(data => new Channel(data.channel, this.#manager.client));
+        }).then(data => Channel.from<T>(data.channel, this.#manager.client));
     }
 
     /** Delete a channel.

--- a/lib/structures/BannedMember.ts
+++ b/lib/structures/BannedMember.ts
@@ -2,10 +2,13 @@
 import { Client } from "./Client";
 import { User } from "./User";
 import { Guild } from "./Guild";
+import { Base } from "./Base";
+import { Member } from "./Member";
 import { APIGuildMemberBan, APIUser } from "../Constants";
+import { JSONBannedMember } from "../types/json";
 
 /** BannedMember represents a banned guild member. */
-export class BannedMember extends User {
+export class BannedMember extends Base<string> {
     /** Server ID. */
     guildID: string;
     /** Information about the banned member (object) */
@@ -17,19 +20,49 @@ export class BannedMember extends User {
         /** ID of the member who banned this member. */
         bannedBy: string;
     };
+    /** Banned user. */
+    user: User;
+    /** Banned member, if cached. */
+    member: Member | null;
     /**
      * @param guildID ID of the guild.
      * @param data raw data.
      * @param client client.
      */
     constructor(guildID: string, data: APIGuildMemberBan, client: Client){
-        super(data.user as APIUser, client);
+        super(data.user.id, client);
         this.guildID = guildID;
         this.ban = {
             reason:    data.reason,
             createdAt: data.createdAt ? new Date(data.createdAt) : null,
             bannedBy:  data.createdBy
         };
+        this.user = client.users.update(data.user) ?? new User(data.user as APIUser, client);
+        this.member = client.getGuild(guildID)?.members.get(data.user.id) ?? null;
+        this.update(data);
+    }
+
+    override toJSON(): JSONBannedMember {
+        return {
+            ...super.toJSON(),
+            guildID: this.guildID,
+            ban:     this.ban
+        };
+    }
+
+    protected override update(data: APIGuildMemberBan): void {
+        if (data.createdAt !== undefined) {
+            this.ban.createdAt = new Date(data.createdAt);
+        }
+        if (data.createdBy !== undefined) {
+            this.ban.bannedBy = data.createdBy;
+        }
+        if (data.reason !== undefined) {
+            this.ban.reason = data.reason;
+        }
+        if (data.user !== undefined && this.client.users.update(data.user)) {
+            this.user = this.client.users.update(data.user);
+        }
     }
 
     /** Getter used to get the message's guild
@@ -37,6 +70,6 @@ export class BannedMember extends User {
      * Note: this can return a promise, make sure to await it before.
      */
     get guild(): Guild | Promise<Guild> {
-        return this.client.cache.guilds.get(this.guildID) ?? this.client.rest.guilds.getGuild(this.guildID);
+        return this.client.guilds.get(this.guildID) ?? this.client.rest.guilds.getGuild(this.guildID);
     }
 }

--- a/lib/structures/Base.ts
+++ b/lib/structures/Base.ts
@@ -1,14 +1,16 @@
 /** @module Base */
 
 import type { Client } from "./Client";
+import { JSONBase } from "../types/json";
+import { inspect } from "node:util";
 
 /** Default information that every other structure has. */
-export abstract class Base {
+export abstract class Base<ID= string | number> {
     /** Bot's client. */
     client!: Client;
     /** Item ID */
-    id: string|number;
-    constructor(id: string | number, client: Client){
+    id: ID;
+    constructor(id: ID, client: Client){
         this.id = id;
         Object.defineProperty(this, "client", {
             value:        client,
@@ -19,4 +21,23 @@ export abstract class Base {
     }
     // eslint-disable-next-line @typescript-eslint/no-empty-function, @typescript-eslint/no-unused-vars
     protected update(data: unknown): void {}
+
+    /** @hidden */
+    [inspect.custom](): this {
+        // https://stackoverflow.com/questions/5905492/dynamic-function-name-in-javascript
+        const copy = new { [this.constructor.name]: class {} }[this.constructor.name]() as this;
+        for (const key in this) {
+            if (Object.hasOwn(this, key) && !key.startsWith("_") && this[key] !== undefined) {
+                copy[key] = this[key];
+            }
+        }
+
+        return copy;
+    }
+
+    toJSON(): JSONBase<ID> {
+        return {
+            id: this.id
+        };
+    }
 }

--- a/lib/structures/CalendarChannel.ts
+++ b/lib/structures/CalendarChannel.ts
@@ -1,0 +1,30 @@
+/** @module CalendarChannel */
+import { Client } from "./Client";
+
+import { CalendarEvent } from "./CalendarEvent";
+import { GuildChannel } from "./GuildChannel";
+import type { APICalendarEvent, APIGuildChannel } from "../Constants";
+import TypedCollection from "../util/TypedCollection";
+import { JSONCalendarChannel } from "../types/json";
+
+/** Represents a calendar channel. */
+export class CalendarChannel extends GuildChannel {
+    /** Cached scheduled events. */
+    scheduledEvents: TypedCollection<number, APICalendarEvent, CalendarEvent>;
+    /**
+     * @param data raw data
+     * @param client client
+     */
+    constructor(data: APIGuildChannel, client: Client){
+        super(data, client);
+        this.scheduledEvents = new TypedCollection(CalendarEvent, client, client.params.collectionLimits?.scheduledEvents);
+        this.update(data);
+    }
+
+    override toJSON(): JSONCalendarChannel {
+        return {
+            ...super.toJSON(),
+            scheduledEvents: this.scheduledEvents
+        };
+    }
+}

--- a/lib/structures/CalendarRSVP.ts
+++ b/lib/structures/CalendarRSVP.ts
@@ -2,13 +2,14 @@
 import { Client } from "./Client";
 import { Base } from "./Base";
 import { APICalendarEventRSVP, APICalendarEventRSVPStatuses, PUTCalendarEventRSVPBody } from "../Constants";
+import { JSONCalendarEventRSVP } from "../types/json";
 
 /** CalendarEventRSVP represents a guild member's event RSVP.
  * It gives information about a member's set presence to an event.
  */
-export class CalendarEventRSVP extends Base {
+export class CalendarEventRSVP extends Base<number> {
     /** Raw data */
-    data: APICalendarEventRSVP;
+    #data: APICalendarEventRSVP;
     /** Guild/server ID. */
     guildID: string;
     /** Calendar channel id. */
@@ -21,6 +22,8 @@ export class CalendarEventRSVP extends Base {
     createdAt: Date | null;
     /** ID of the user who created this RSVP. */
     creatorID: string;
+    /** When the RSVP was updated. */
+    updatedAt: Date | null;
     /** ID of the member who updated the rsvp, if updated. */
     updatedBy?: string | null;
 
@@ -30,14 +33,60 @@ export class CalendarEventRSVP extends Base {
      */
     constructor(data: APICalendarEventRSVP, client: Client){
         super(data.calendarEventId, client);
-        this.data = data;
+        this.#data = data;
         this.guildID = data.serverId;
         this.channelID = data.channelId;
         this.entityID = data.userId;
         this.status = data.status;
         this.creatorID = data.createdBy ?? null;
         this.updatedBy = data.updatedBy ?? null;
+        this.updatedAt = data.updatedAt ? new Date(data.updatedAt) : null;
         this.createdAt = data.createdAt ? new Date(data.createdAt) : null;
+        this.update(data);
+    }
+
+    override toJSON(): JSONCalendarEventRSVP {
+        return {
+            ...super.toJSON(),
+            guildID:   this.guildID,
+            channelID: this.channelID,
+            entityID:  this.entityID,
+            status:    this.status,
+            creatorID: this.creatorID,
+            updatedBy: this.updatedBy,
+            updatedAt: this.updatedAt,
+            createdAt: this.createdAt
+        };
+    }
+
+    protected override update(data: APICalendarEventRSVP): void {
+        if (data.calendarEventId !== undefined) {
+            this.id = data.calendarEventId;
+        }
+        if (data.channelId !== undefined) {
+            this.channelID = data.channelId;
+        }
+        if (data.createdAt !== undefined) {
+            this.createdAt = new Date(data.createdAt);
+        }
+        if (data.createdBy !== undefined) {
+            this.creatorID = data.createdBy;
+        }
+        if (data.serverId !== undefined) {
+            this.guildID = data.serverId;
+        }
+        if (data.status !== undefined) {
+            this.status = data.status;
+        }
+        if (data.updatedAt !== undefined) {
+            this.updatedAt = new Date(data.updatedAt);
+        }
+        if (data.updatedBy !== undefined) {
+            this.updatedBy = data.updatedBy;
+        }
+        if (data.userId !== undefined) {
+            this.entityID = data.userId;
+        }
     }
 
     /** Edit this RSVP. */

--- a/lib/structures/Channel.ts
+++ b/lib/structures/Channel.ts
@@ -1,39 +1,22 @@
 /** @module Channel */
 import { Client } from "./Client";
-import { Message } from "./Message";
 
 import { Base } from "./Base";
-import { CreateMessageOptions, EditChannelOptions } from "../types/channel";
+import { GuildChannel } from "./GuildChannel";
+import { CalendarChannel } from "./CalendarChannel";
+import { DocChannel } from "./DocChannel";
+import { ForumChannel } from "./ForumChannel";
+import { TextChannel } from "./TextChannel";
+import { JSONChannel } from "../types/json";
 import type { APIGuildChannel } from "../Constants";
+import { AnyChannel, EditChannelOptions } from "../types/channel";
 
-/** Represents a guild channel. */
-export class Channel extends Base {
+/** Represents a channel. */
+export class Channel extends Base<string> {
     /** Channel type */
     type: string;
     /** Channel name */
-    name: string;
-    /** Channel description */
-    description: string | null;
-    /** When this channel was created. */
-    createdAt: Date;
-    /** ID of the member who created this channel. */
-    creatorID: string;
-    /** Timestamp at which this channel was last edited. */
-    editedTimestamp: Date | null;
-    /** Server ID */
-    guildID: string;
-    /** ID of the parent category. */
-    parentID: string | null;
-    /** ID of the category the channel is in. */
-    categoryID: number | null;
-    /** ID of the group the channel is in. */
-    groupID: string;
-    isPublic: boolean;
-    /** ID of the member that archived the channel (if archived) */
-    archivedBy: string | null;
-    /** When the channel was last archived. */
-    archivedAt: Date | null;
-
+    name: string | null;
     /**
      * @param data raw data
      * @param client client
@@ -42,22 +25,52 @@ export class Channel extends Base {
         super(data.id, client);
         this.type = data.type;
         this.name = data.name;
-        this.description = data.topic ?? null;
-        this.createdAt = new Date(data.createdAt);
-        this.creatorID = data.createdBy;
-        this.editedTimestamp = data.updatedAt ? new Date(data.updatedAt) : null;
-        this.guildID = data.serverId;
-        this.parentID = data.parentId ?? null;
-        this.categoryID = data.categoryId ?? null;
-        this.groupID = data.groupId;
-        this.isPublic = data.isPublic ?? false;
-        this.archivedBy = data.archivedBy ?? null;
-        this.archivedAt = data.archivedAt ? new Date(data.archivedAt) : null;
     }
 
-    /** Create a message in the channel. */
-    async createMessage(options: CreateMessageOptions): Promise<Message>{
-        return this.client.rest.channels.createMessage(this.id as string, options);
+    static from<T extends AnyChannel = AnyChannel>(data: APIGuildChannel, client: Client): T {
+        switch (data.type) {
+            case "announcement": {
+                return new GuildChannel(data, client) as T;
+            }
+            case "calendar": {
+                return new CalendarChannel(data, client) as T;
+            }
+            case "chat": {
+                return new TextChannel(data, client) as T;
+            }
+            case "docs": {
+                return new DocChannel(data, client) as T;
+            }
+            case "forums": {
+                return new ForumChannel(data, client) as T;
+            }
+            case "list": {
+                return new GuildChannel(data, client) as T;
+            }
+            case "media": {
+                return new GuildChannel(data, client) as T;
+            }
+            case "scheduling": {
+                return new GuildChannel(data, client) as T;
+            }
+            case "stream": {
+                return new GuildChannel(data, client) as T;
+            }
+            case "voice": {
+                return new GuildChannel(data, client) as T;
+            }
+            default: {
+                return new Channel(data, client) as T;
+            }
+        }
+    }
+
+    override toJSON(): JSONChannel {
+        return {
+            ...super.toJSON(),
+            type: this.type,
+            name: this.name
+        };
     }
 
     /** Edit the channel. */

--- a/lib/structures/DocChannel.ts
+++ b/lib/structures/DocChannel.ts
@@ -1,0 +1,30 @@
+/** @module DocChannel */
+import { Client } from "./Client";
+
+import { Doc } from "./Doc";
+import { GuildChannel } from "./GuildChannel";
+import type { APIDoc, APIGuildChannel } from "../Constants";
+import TypedCollection from "../util/TypedCollection";
+import { JSONDocChannel } from "../types/json";
+
+/** Represents a "docs" channel. */
+export class DocChannel extends GuildChannel {
+    /** Cached docs. */
+    docs: TypedCollection<number, APIDoc, Doc>;
+    /**
+     * @param data raw data
+     * @param client client
+     */
+    constructor(data: APIGuildChannel, client: Client){
+        super(data, client);
+        this.docs = new TypedCollection(Doc, client, client.params.collectionLimits?.docs);
+        this.update(data);
+    }
+
+    override toJSON(): JSONDocChannel {
+        return {
+            ...super.toJSON(),
+            docs: this.docs
+        };
+    }
+}

--- a/lib/structures/ForumChannel.ts
+++ b/lib/structures/ForumChannel.ts
@@ -1,0 +1,31 @@
+/** @module ForumChannel */
+import { Client } from "./Client";
+
+import { ForumThread } from "./ForumThread";
+import { GuildChannel } from "./GuildChannel";
+import { AnyChannel } from "../types/channel";
+import type { APIForumTopic, APIGuildChannel } from "../Constants";
+import TypedCollection from "../util/TypedCollection";
+import { JSONForumChannel } from "../types/json";
+
+/** Represents a forum channel. */
+export class ForumChannel extends GuildChannel {
+    /** Cached threads. */
+    threads: TypedCollection<number, APIForumTopic, ForumThread<AnyChannel>>;
+    /**
+     * @param data raw data
+     * @param client client
+     */
+    constructor(data: APIGuildChannel, client: Client){
+        super(data, client);
+        this.threads = new TypedCollection(ForumThread, client, client.params.collectionLimits?.threads);
+        this.update(data);
+    }
+
+    override toJSON(): JSONForumChannel {
+        return {
+            ...super.toJSON(),
+            threads: this.threads
+        };
+    }
+}

--- a/lib/structures/ForumThreadReactionInfo.ts
+++ b/lib/structures/ForumThreadReactionInfo.ts
@@ -1,6 +1,7 @@
 /** @module ForumThreadReactionInfo */
 import { ReactionInfo } from "./ReactionInfo";
 import { Client } from "./Client";
+import { ForumChannel } from "./ForumChannel";
 import { ForumThreadReactionTypes } from "../types/types";
 import { GatewayEvent_ForumTopicReactionCreated, GatewayEvent_ForumTopicReactionDeleted } from "../Constants";
 
@@ -21,9 +22,9 @@ export class ForumThreadReactionInfo extends ReactionInfo {
      * otherwise it'll return basic information about this thread.
      */
     get thread(): ForumThreadReactionTypes["thread"] {
-        return this.client.cache.forumThreads.get(this.#threadID) ?? {
+        return this.client.getChannel<ForumChannel>(this.data.serverId as string, this.data.reaction.channelId)?.threads.get(this.#threadID) ?? {
             id:    this.#threadID,
-            guild: this.client.cache.guilds.get(this.data.serverId as string) ?? {
+            guild: this.client.guilds.get(this.data.serverId as string) ?? {
                 id: this.data.serverId
             },
             channelID: this.data.reaction.channelId

--- a/lib/structures/ForumThreadReactionInfo.ts
+++ b/lib/structures/ForumThreadReactionInfo.ts
@@ -1,7 +1,7 @@
 /** @module ForumThreadReactionInfo */
 import { ReactionInfo } from "./ReactionInfo";
 import { Client } from "./Client";
-import { forumThreadReactionInfo } from "../types/types";
+import { ForumThreadReactionTypes } from "../types/types";
 import { GatewayEvent_ForumTopicReactionCreated, GatewayEvent_ForumTopicReactionDeleted } from "../Constants";
 
 /** Information about a ForumThread's reaction. */
@@ -20,7 +20,7 @@ export class ForumThreadReactionInfo extends ReactionInfo {
      * If the thread is cached, it'll return a ForumThread component,
      * otherwise it'll return basic information about this thread.
      */
-    get thread(): forumThreadReactionInfo["thread"] {
+    get thread(): ForumThreadReactionTypes["thread"] {
         return this.client.cache.forumThreads.get(this.#threadID) ?? {
             id:    this.#threadID,
             guild: this.client.cache.guilds.get(this.data.serverId as string) ?? {

--- a/lib/structures/Guild.ts
+++ b/lib/structures/Guild.ts
@@ -5,10 +5,15 @@ import { Channel } from "./Channel";
 import { Member } from "./Member";
 import { User } from "./User";
 import { BannedMember } from "./BannedMember";
-import { APIGuild } from "../Constants";
+import { GuildChannel } from "./GuildChannel";
+import { APIGuild, APIGuildChannel, APIGuildMember } from "../Constants";
+import TypedCollection from "../util/TypedCollection";
+import { JSONGuild } from "../types/json";
+import { AnyChannel } from "../types/channel";
 
 /** Represents a Guild, also called server. */
-export class Guild extends Base {
+export class Guild extends Base<string> {
+    private _clientMember?: Member;
     /** ID of the guild owner. */
     ownerID: string;
     /** Guild type. */
@@ -29,6 +34,12 @@ export class Guild extends Base {
     defaultChannelID?: string;
     /** When this guild was created. */
     createdAt: Date;
+    /** If true, the guild is verified. */
+    verified: boolean;
+    /** Cached guild channels. */
+    channels: TypedCollection<string, APIGuildChannel, AnyChannel>;
+    /** Cached guild members. */
+    members: TypedCollection<string, APIGuildMember, Member, [guildID: string]>;
 
     /**
      * @param data raw data.
@@ -46,27 +57,89 @@ export class Guild extends Base {
         this.timezone = data.timezone;
         this.defaultChannelID = data.defaultChannelId;
         this.createdAt = new Date(data.createdAt);
+        this.verified = data.isVerified ?? false;
+        this.channels = new TypedCollection(GuildChannel, client);
+        this.members = new TypedCollection(Member, client);
+        this.update(data);
     }
 
-    /** Retrieve guild's owner, if cached.
-     * If there is no cached member or user, this will make a request which returns a Promise.
-     * If the request fails, this will throw an error or return you undefined as a value.
-     */
-    get owner(): Member | User | Promise<Member> | undefined {
-        if (this.client.cache.members.get(this.ownerID) && this.ownerID){
-            return this.client.cache.members.get(this.ownerID);
-        } else if (this.client.cache.users.get(this.ownerID) && this.ownerID){
-            return this.client.cache.users.get(this.ownerID);
-        } else if (this.ownerID && this.id){
-            return this.client.rest.guilds.getMember(this.id as string, this.ownerID);
+    override toJSON(): JSONGuild {
+        return {
+            ...super.toJSON(),
+            ownerID:          this.ownerID,
+            type:             this.type,
+            name:             this.name,
+            url:              this.url,
+            description:      this.description,
+            iconURL:          this.iconURL,
+            bannerURL:        this.bannerURL,
+            timezone:         this.timezone,
+            defaultChannelID: this.defaultChannelID,
+            createdAt:        this.createdAt,
+            verified:         this.verified,
+            channels:         this.channels,
+            members:          this.members
+        };
+    }
+
+    protected override update(data: APIGuild): void {
+        if (data.about !== undefined) {
+            this.description = data.about;
+        }
+        if (data.avatar !== undefined) {
+            this.iconURL = data.avatar;
+        }
+        if (data.banner !== undefined) {
+            this.bannerURL = data.banner;
+        }
+        if (data.createdAt !== undefined) {
+            this.createdAt = new Date(data.createdAt);
+        }
+        if (data.defaultChannelId !== undefined) {
+            this.defaultChannelID = data.defaultChannelId;
+        }
+        if (data.id !== undefined) {
+            this.id = data.id;
+        }
+        if (data.isVerified !== undefined) {
+            this.verified = data.isVerified;
+        }
+        if (data.name !== undefined) {
+            this.name = data.name;
+        }
+        if (data.ownerId !== undefined) {
+            this.ownerID = data.ownerId;
+        }
+        if (data.timezone !== undefined) {
+            this.timezone = data.timezone;
+        }
+        if (data.type !== undefined) {
+            this.type = data.type;
+        }
+        if (data.url !== undefined) {
+            this.url = data.url;
         }
     }
 
-    /** Get a channel from this guild.
-     * @param channelID The ID of the channel to get.
+    /** Retrieve cached or rest guild's owner. */
+    get owner(): Member | User | Promise<Member> {
+        return this.client.getGuild(this.id)?.members.get(this.ownerID) ?? this.client.users.get(this.ownerID) ?? this.client.rest.guilds.getMember(this.id, this.ownerID);
+    }
+
+    /** Get a channel from this guild, if cached.
+     * @param channelID The ID of the channel to get from cache.
      */
-    async getChannel(channelID: string): Promise<Channel>{
-        return this.client.rest.channels.getChannel(channelID);
+    getChannel(channelID: string): Channel | undefined {
+        if (!channelID) throw new Error("channelID is a required parameter.");
+        return this.channels.get(channelID);
+    }
+
+    /** Get a member from this guild, if cached.
+     * @param memberID The ID of the member to get.
+     */
+    getMember(memberID: string): Member | undefined {
+        if (!memberID) throw new Error("memberID is a required parameter.");
+        return this.members.get(memberID);
     }
 
     /** Ban a member.

--- a/lib/structures/GuildChannel.ts
+++ b/lib/structures/GuildChannel.ts
@@ -1,0 +1,144 @@
+/** @module GuildChannel */
+import { Client } from "./Client";
+
+import { Base } from "./Base";
+import { Channel } from "./Channel";
+import { EditChannelOptions } from "../types/channel";
+import type { APIGuildChannel } from "../Constants";
+import { JSONGuildChannel } from "../types/json";
+
+/** Represents a guild channel. */
+export class GuildChannel extends Base<string> {
+    /** Channel type */
+    type: string;
+    /** Channel name */
+    name: string;
+    /** Channel description */
+    description: string | null;
+    /** When this channel was created. */
+    createdAt: Date;
+    /** ID of the member who created this channel. */
+    creatorID: string;
+    /** Timestamp at which this channel was last edited. */
+    editedTimestamp: Date | null;
+    /** Server ID */
+    guildID: string;
+    /** ID of the parent category. */
+    parentID: string | null;
+    /** ID of the category the channel is in. */
+    categoryID: number | null;
+    /** ID of the group the channel is in. */
+    groupID: string;
+    isPublic: boolean;
+    /** ID of the member that archived the channel (if archived) */
+    archivedBy: string | null;
+    /** When the channel was last archived. */
+    archivedAt: Date | null;
+    // /** Cached messages. */
+    // messages: TypedCollection<string, APIChatMessage, Message<AnyTextableChannel>>;
+    // /** Cached threads. */
+    // threads: TypedCollection<number, APIForumTopic, ForumThread<AnyTextableChannel>>;
+    // /** Cached docs. */
+    // docs: TypedCollection<number, APIDoc, Doc>;
+    // /** Cached scheduled events. */
+    // scheduledEvents: TypedCollection<number, APICalendarEvent, CalendarEvent>;
+    /**
+     * @param data raw data
+     * @param client client
+     */
+    constructor(data: APIGuildChannel, client: Client){
+        super(data.id, client);
+        this.type = data.type;
+        this.name = data.name;
+        this.description = data.topic ?? null;
+        this.createdAt = new Date(data.createdAt);
+        this.creatorID = data.createdBy;
+        this.editedTimestamp = data.updatedAt ? new Date(data.updatedAt) : null;
+        this.guildID = data.serverId;
+        this.parentID = data.parentId ?? null;
+        this.categoryID = data.categoryId ?? null;
+        this.groupID = data.groupId;
+        this.isPublic = data.isPublic ?? false;
+        this.archivedBy = data.archivedBy ?? null;
+        this.archivedAt = data.archivedAt ? new Date(data.archivedAt) : null;
+        // this.messages = new TypedCollection(Message, client, client.params.collectionLimits?.messages);
+        // this.threads = new TypedCollection(ForumThread, client, client.params.collectionLimits?.threads);
+        // this.docs = new TypedCollection(Doc, client, client.params.collectionLimits?.docs);
+        // this.scheduledEvents = new TypedCollection(CalendarEvent, client, client.params.collectionLimits?.scheduledEvents);
+        this.update(data);
+    }
+
+    override toJSON(): JSONGuildChannel {
+        return {
+            ...super.toJSON(),
+            type:            this.type,
+            name:            this.name,
+            description:     this.description,
+            createdAt:       this.createdAt,
+            creatorID:       this.creatorID,
+            editedTimestamp: this.editedTimestamp,
+            guildID:         this.guildID,
+            parentID:        this.parentID,
+            categoryID:      this.categoryID,
+            groupID:         this.groupID,
+            isPublic:        this.isPublic,
+            archivedBy:      this.archivedBy,
+            archivedAt:      this.archivedAt
+        };
+    }
+
+    protected override update(data: APIGuildChannel): void {
+        if (data.archivedAt !== undefined) {
+            this.archivedAt = new Date(data.archivedAt);
+        }
+        if (data.archivedBy !== undefined) {
+            this.archivedBy = data.archivedBy;
+        }
+        if (data.categoryId !== undefined) {
+            this.categoryID = data.categoryId;
+        }
+        if (data.createdAt !== undefined) {
+            this.createdAt = new Date(data.createdAt);
+        }
+        if (data.createdBy !== undefined) {
+            this.creatorID = data.createdBy;
+        }
+        if (data.groupId !== undefined) {
+            this.groupID = data.groupId;
+        }
+        if (data.id !== undefined) {
+            this.id = data.id;
+        }
+        if (data.isPublic !== undefined) {
+            this.isPublic = data.isPublic;
+        }
+        if (data.name !== undefined) {
+            this.name = data.name;
+        }
+        if (data.parentId !== undefined) {
+            this.parentID = data.parentId;
+        }
+        if (data.serverId !== undefined) {
+            this.guildID = data.serverId;
+        }
+        if (data.topic !== undefined) {
+            this.description = data.topic;
+        }
+        if (data.type !== undefined) {
+            this.type = data.type;
+        }
+        if (data.updatedAt !== undefined) {
+            this.editedTimestamp = new Date(data.updatedAt);
+        }
+    }
+
+    /** Edit the channel. */
+    async edit(options: EditChannelOptions): Promise<Channel>{
+        return this.client.rest.guilds.editChannel(this.id as string, options);
+    }
+
+    /** Delete the channel. */
+    async delete(): Promise<void>{
+        return this.client.rest.guilds.deleteChannel(this.id as string);
+    }
+}

--- a/lib/structures/MemberInfo.ts
+++ b/lib/structures/MemberInfo.ts
@@ -19,10 +19,10 @@ export abstract class MemberInfo {
     }
 
     get guild(): Guild | Promise<Guild> {
-        return this.client!.cache.guilds.get(this.guildID) ?? this.client!.rest.guilds.getGuild(this.guildID);
+        return this.client!.guilds.get(this.guildID) ?? this.client!.rest.guilds.getGuild(this.guildID);
     }
 
     get member(): Member | Promise<Member> {
-        return this.client!.cache.members.get(this.memberID) ?? this.client!.rest.guilds.getMember(this.guildID, this.memberID);
+        return this.client!.getGuild(this.guildID)?.members.get(this.memberID) ?? this.client!.rest.guilds.getMember(this.guildID, this.memberID);
     }
 }

--- a/lib/structures/MemberUpdateInfo.ts
+++ b/lib/structures/MemberUpdateInfo.ts
@@ -29,16 +29,6 @@ export class MemberUpdateInfo extends MemberInfo {
         super(data, memberID, client);
         this.updatedNickname = (data as GWMUpdated)?.userInfo?.nickname ?? null;
         this.roles = (data as GWRolesUpdated)?.memberRoleIds?.[0]?.roleIds ?? null;
-        this.oldRoles = (this.client.cache.members.get(this.memberID))?.roles ?? null;
-        this.updateCache.bind(this)();
-    }
-
-    private updateCache(): void {
-        const CachedMember = this.client.cache.members.get(this.memberID);
-        if (CachedMember){
-            if (!this.roles) return;
-            CachedMember.roles = this.roles;
-            this.client.cache.members.add(CachedMember);
-        }
+        this.oldRoles = (this.client.getGuild(data.serverId)?.members.get(this.memberID))?.roles ?? null;
     }
 }

--- a/lib/structures/MessageReactionInfo.ts
+++ b/lib/structures/MessageReactionInfo.ts
@@ -1,5 +1,6 @@
 /** @module MessageReactionInfo */
 import { ReactionInfo } from "./ReactionInfo";
+import { TextChannel } from "./TextChannel";
 import { Client } from "../structures/Client";
 import { MessageReactionTypes } from "../types/types";
 import { GatewayEvent_ChannelMessageReactionAdded, GatewayEvent_ChannelMessageReactionDeleted } from "../Constants";
@@ -21,9 +22,10 @@ export class MessageReactionInfo extends ReactionInfo {
      * otherwise it'll return basic information about this message.
      */
     get message(): MessageReactionTypes["message"] {
-        return this.client.cache.messages.get(this.#messageID) ?? {
+        const channel = this.client.getChannel<TextChannel>(this.data.serverId as string, this.data.reaction.channelId);
+        return channel?.messages?.get(this.#messageID) ?? {
             id:    this.#messageID,
-            guild: this.client.cache.guilds.get(this.data.serverId as string) ?? {
+            guild: this.client.guilds.get(this.data.serverId as string) ?? {
                 id: this.data.serverId
             },
             channelID: this.data.reaction.channelId

--- a/lib/structures/MessageReactionInfo.ts
+++ b/lib/structures/MessageReactionInfo.ts
@@ -1,7 +1,7 @@
 /** @module MessageReactionInfo */
 import { ReactionInfo } from "./ReactionInfo";
 import { Client } from "../structures/Client";
-import { messageReactionInfo } from "../types/types";
+import { MessageReactionTypes } from "../types/types";
 import { GatewayEvent_ChannelMessageReactionAdded, GatewayEvent_ChannelMessageReactionDeleted } from "../Constants";
 
 /** Information about a Message's reaction. */
@@ -20,7 +20,7 @@ export class MessageReactionInfo extends ReactionInfo {
      * If the message is cached, it'll return a Message component,
      * otherwise it'll return basic information about this message.
      */
-    get message(): messageReactionInfo["message"] {
+    get message(): MessageReactionTypes["message"] {
         return this.client.cache.messages.get(this.#messageID) ?? {
             id:    this.#messageID,
             guild: this.client.cache.guilds.get(this.data.serverId as string) ?? {

--- a/lib/structures/ReactionInfo.ts
+++ b/lib/structures/ReactionInfo.ts
@@ -36,7 +36,7 @@ export class ReactionInfo {
 
     /** Cached member. If member isn't cached will return an object with the member's id. */
     get reactor(): Member | { id: string; } {
-        return this.client.cache.members.get(this.data.reaction.createdBy) ?? {
+        return this.client.getGuild(this.data.serverId as string)?.members.get(this.data.reaction.createdBy) ?? {
             id: this.data.reaction.createdBy
         };
     }

--- a/lib/structures/TextChannel.ts
+++ b/lib/structures/TextChannel.ts
@@ -1,0 +1,31 @@
+/** @module TextChannel */
+import { Client } from "./Client";
+
+import { Message } from "./Message";
+import { GuildChannel } from "./GuildChannel";
+import { AnyTextableChannel } from "../types/channel";
+import type { APIChatMessage, APIGuildChannel } from "../Constants";
+import TypedCollection from "../util/TypedCollection";
+import { JSONTextChannel } from "../types/json";
+
+/** Represents a guild channel. */
+export class TextChannel extends GuildChannel {
+    /** Cached messages. */
+    messages: TypedCollection<string, APIChatMessage, Message<AnyTextableChannel>>;
+    /**
+     * @param data raw data
+     * @param client client
+     */
+    constructor(data: APIGuildChannel, client: Client){
+        super(data, client);
+        this.messages = new TypedCollection(Message, client, client.params.collectionLimits?.messages);
+        this.update(data);
+    }
+
+    override toJSON(): JSONTextChannel {
+        return {
+            ...super.toJSON(),
+            messages: this.messages
+        };
+    }
+}

--- a/lib/structures/User.ts
+++ b/lib/structures/User.ts
@@ -1,10 +1,11 @@
 /** @module User */
 import { Client } from "./Client";
 import { Base } from "./Base";
-import { UserTypes, APIUser } from "../Constants";
+import { UserTypes, APIUser, APIGuildMember, APIUserSummary } from "../Constants";
+import { JSONUser } from "../types/json";
 
 /** Represents a user. */
-export class User extends Base {
+export class User extends Base<string> {
     /** User type */
     type: UserTypes | null;
     /** User's username. */
@@ -32,5 +33,41 @@ export class User extends Base {
 
         if (!this.type) this.type = "user"; // since it's only defined when it's a bot.
         this.bot = this.type === "bot" ? true : false;
+
+        this.update(data);
+    }
+
+    override toJSON(): JSONUser {
+        return {
+            ...super.toJSON(),
+            type:      this.type,
+            username:  this.username,
+            createdAt: this.createdAt,
+            avatarURL: this.avatarURL,
+            bannerURL: this.bannerURL,
+            bot:       this.bot
+        };
+    }
+
+    protected override update(d: APIUser | APIGuildMember | APIUserSummary): void {
+        const data = d as APIUser;
+        if (data.avatar !== undefined) {
+            this.avatarURL = data.avatar ?? null;
+        }
+        if (data.banner !== undefined) {
+            this.bannerURL = data.banner ?? null;
+        }
+        if (data.createdAt !== undefined) {
+            this.createdAt = new Date(data.createdAt);
+        }
+        if (data.id !== undefined) {
+            this.id = data.id;
+        }
+        if (data.name !== undefined) {
+            this.username = data.name;
+        }
+        if (data.type !== undefined) {
+            this.type = data.type ?? null;
+        }
     }
 }

--- a/lib/structures/UserClient.ts
+++ b/lib/structures/UserClient.ts
@@ -2,9 +2,10 @@
 import { Client } from "./Client";
 import { Base } from "./Base";
 import { APIBotUser } from "../Constants";
+import { JSONUserClient } from "../types/json";
 
 /** UserClient represents the logged bot's user. */
-export class UserClient extends Base {
+export class UserClient extends Base<string> {
     /** Client User Bot ID */
     botID: string;
     /** User type (user, bot) */
@@ -26,6 +27,36 @@ export class UserClient extends Base {
         this.username = data.name;
         this.createdAt = new Date(data.createdAt);
         this.ownerID = data.createdBy;
+        this.update(data);
+    }
+
+    override toJSON(): JSONUserClient {
+        return {
+            ...super.toJSON(),
+            botID:     this.botID,
+            type:      this.type,
+            username:  this.username,
+            createdAt: this.createdAt,
+            ownerID:   this.ownerID
+        };
+    }
+
+    protected override update(data: APIBotUser["user"]): void {
+        if (data.botId !== undefined) {
+            this.botID = data.botId;
+        }
+        if (data.createdAt !== undefined) {
+            this.createdAt = new Date(data.createdAt);
+        }
+        if (data.createdBy !== undefined) {
+            this.ownerID = data.createdBy;
+        }
+        if (data.id !== undefined) {
+            this.id = data.id;
+        }
+        if (data.name !== undefined) {
+            this.username = data.name;
+        }
     }
 
     /** Boolean that shows if the user is a bot or not.

--- a/lib/structures/Webhook.ts
+++ b/lib/structures/Webhook.ts
@@ -3,9 +3,10 @@ import { Client } from "./Client";
 import { Base } from "./Base";
 import { APIWebhook } from "../Constants";
 import { WebhookEditOptions } from "../types/webhook";
+import { JSONWebhook } from "../types/json";
 
 /** Represents a Guild or channel webhook. */
-export class Webhook extends Base {
+export class Webhook extends Base<string> {
     /** ID of the guild, where the webhook comes from. */
     guildID: string;
     /** ID of the channel, where the webhook comes from. */
@@ -34,15 +35,56 @@ export class Webhook extends Base {
         this.deletedAt = data.deletedAt ? new Date(data.deletedAt) : null;
         this.ownerID = data.createdBy;
         this.token = data.token ?? null;
+        this.update(data);
+    }
+
+    override toJSON(): JSONWebhook {
+        return {
+            ...super.toJSON(),
+            guildID:   this.guildID,
+            channelID: this.channelID,
+            username:  this.username,
+            createdAt: this.createdAt,
+            deletedAt: this.deletedAt,
+            ownerID:   this.ownerID,
+            token:     this.token
+        };
+    }
+
+    protected override update(data: APIWebhook): void {
+        if (data.channelId !== undefined) {
+            this.channelID = data.channelId;
+        }
+        if (data.createdAt !== undefined) {
+            this.createdAt = new Date(data.createdAt);
+        }
+        if (data.createdBy !== undefined) {
+            this.ownerID = data.createdBy;
+        }
+        if (data.deletedAt !== undefined) {
+            this.deletedAt = new Date(data.deletedAt);
+        }
+        if (data.id !== undefined) {
+            this.id = data.id;
+        }
+        if (data.name !== undefined) {
+            this.username = data.name;
+        }
+        if (data.serverId !== undefined) {
+            this.guildID = data.serverId;
+        }
+        if (data.token !== undefined) {
+            this.token = data.token;
+        }
     }
 
     /** Update the webhook. */
     async edit(options: WebhookEditOptions): Promise<Webhook>{
-        return this.client.rest.guilds.editWebhook(this.guildID, this.id as string, options);
+        return this.client.rest.guilds.editWebhook(this.guildID, this.id, options);
     }
 
     /** Delete the webhook. */
     async delete(): Promise<void>{
-        return this.client.rest.guilds.deleteWebhook(this.guildID, this.id as string);
+        return this.client.rest.guilds.deleteWebhook(this.guildID, this.id);
     }
 }

--- a/lib/types/channel.d.ts
+++ b/lib/types/channel.d.ts
@@ -1,4 +1,9 @@
 import type { Message } from "../structures/Message";
+import { GuildChannel } from "../structures/GuildChannel";
+import { TextChannel } from "../structures/TextChannel";
+import { ForumChannel } from "../structures/ForumChannel";
+import { DocChannel } from "../structures/DocChannel";
+import { CalendarChannel } from "../structures/CalendarChannel";
 import type { APIEmbedField } from "guildedapi-types.ts/v1";
 
 export interface CreateMessageOptions {
@@ -103,7 +108,7 @@ export interface GetChannelMessagesFilter {
     includePrivate?: boolean;
 }
 
-export type PossiblyUncachedMessage = Message | {
+export type PossiblyUncachedMessage = Message<AnyTextableChannel> | {
     /** The ID of the message. */
     id: string;
     /** ID of the server on which the message was sent. */
@@ -115,3 +120,7 @@ export type PossiblyUncachedMessage = Message | {
     /** If true, the message is private. */
     isPrivate: boolean | null;
 };
+
+export type AnyTextableChannel = TextChannel;
+export type AnyChannel = GuildChannel | TextChannel | ForumChannel | DocChannel | CalendarChannel;
+export type AnyGuildChannel = Exclude<AnyChannel, GuildChannel>;

--- a/lib/types/client.d.ts
+++ b/lib/types/client.d.ts
@@ -16,6 +16,15 @@ export interface ClientOptions {
      * This includes some properties like the baseURL and much more.
      */
     RESTOptions?: RESTOptions;
+
+    collectionLimits?: {
+        messages?: number;
+        threads?: number;
+        threadComments?: number;
+        docs?: number;
+        scheduledEvents?: number;
+        scheduledEventsRSVPS?: number;
+    };
 }
 
 export interface RESTOptions {

--- a/lib/types/events.d.ts
+++ b/lib/types/events.d.ts
@@ -1,12 +1,12 @@
 /** @module Events */
 import type { AnyReactionInfo, GuildCreateInfo, GuildDeleteInfo } from "./types";
-import { PossiblyUncachedMessage } from "./channel";
+import { AnyChannel, AnyTextableChannel, PossiblyUncachedMessage } from "./channel";
 import type { AnyPacket, WelcomePacket } from "./gateway-raw";
+import { JSONMessage } from "./json";
 import type { BannedMember } from "../structures/BannedMember";
 import type { ForumThread } from "../structures/ForumThread";
 import type { ForumThreadComment } from "../structures/ForumThreadComment";
 import type { Message } from "../structures/Message";
-import type { Channel } from "../structures/Channel";
 import type { MemberRemoveInfo } from "../structures/MemberRemoveInfo";
 import type { MemberUpdateInfo } from "../structures/MemberUpdateInfo";
 import type { ListItem } from "../structures/ListItem";
@@ -28,9 +28,9 @@ export interface ClientEvents {
     /** @event Emitted when the bot is ready. */
     ready: [];
     /** @event Emitted when a message is created in a "chat" channel. */
-    messageCreate: [message: Message];
+    messageCreate: [message: Message<AnyTextableChannel>];
     /** @event Emitted when a message coming from a "chat" channel is edited. */
-    messageUpdate: [message: Message, oldMessage: Message | null];
+    messageUpdate: [message: Message<AnyTextableChannel>, oldMessage: JSONMessage | null];
     /** @event Emitted when a message coming from a "chat" channel is deleted. */
     messageDelete: [message: PossiblyUncachedMessage];
     /** @event Emitted when a reaction is added to anything. */
@@ -38,21 +38,21 @@ export interface ClientEvents {
     /** @event Emitted when a reaction is removed from anything. */
     reactionRemove: [reactionInfo: AnyReactionInfo];
     /** @event Emitted when a guild channel is created. */
-    channelCreate: [channel: Channel];
+    channelCreate: [channel: AnyChannel];
     /** @event Emitted when a guild channel is updated. */
-    channelUpdate: [channel: Channel];
+    channelUpdate: [channel: AnyChannel];
     /** @event Emitted when a guild channel is deleted. */
-    channelDelete: [channel: Channel];
+    channelDelete: [channel: AnyChannel];
     /** @event Emitted when a forum thread is created. */
-    forumThreadCreate: [thread: ForumThread];
+    forumThreadCreate: [thread: ForumThread<AnyChannel>];
     /** @event Emitted when a forum thread is edited. */
-    forumThreadUpdate: [thread: ForumThread];
+    forumThreadUpdate: [thread: ForumThread<AnyChannel>];
     /** @event Emitted when a forum thread is deleted. */
-    forumThreadDelete: [thread: ForumThread];
+    forumThreadDelete: [thread: ForumThread<AnyChannel>];
     /** @event Emitted when a forum thread is pinned. */
-    forumThreadPin: [thread: ForumThread];
+    forumThreadPin: [thread: ForumThread<AnyChannel>];
     /** @event Emitted when a forum thread is unpinned. */
-    forumThreadUnpin: [thread: ForumThread];
+    forumThreadUnpin: [thread: ForumThread<AnyChannel>];
     /** @event Emitted when a thread comment is created. */
     forumCommentCreate: [comment: ForumThreadComment];
     /** @event Emitted when forum thread comment is edited. */
@@ -60,9 +60,9 @@ export interface ClientEvents {
     /** @event Emitted when forum thread is deleted. */
     forumCommentDelete: [comment: ForumThreadComment];
     /** @event Emitted when forum thread got locked. */
-    forumThreadLock: [ForumThread: ForumThread];
+    forumThreadLock: [ForumThread: ForumThread<AnyChannel>];
     /** @event Emitted when forum thread got unlocked. */
-    forumThreadUnlock: [ForumThread: ForumThread];
+    forumThreadUnlock: [ForumThread: ForumThread<AnyChannel>];
     /** @event Emitted when a guild member got banned. */
     guildBanAdd: [BannedMember: BannedMember];
     /** @event Emitted when guild member got unbanned. */

--- a/lib/types/json.d.ts
+++ b/lib/types/json.d.ts
@@ -1,0 +1,350 @@
+import { CalendarEvent } from "../structures/CalendarEvent";
+import { Doc } from "../structures/Doc";
+import { ForumThread } from "../structures/ForumThread";
+import { Message } from "../structures/Message";
+import { APICalendarEvent, APIChatMessage, APIDoc, APIForumTopic } from "guildedapi-types.ts/v1";
+
+export interface JSONBase<ID= string | number> {
+    // createdAt: number;
+    id: ID;
+}
+
+export interface JSONMessage extends JSONBase<string> {
+    /** Message type. */
+    type: string;
+    /** ID of the server on which the message was sent. */
+    guildID: string | null;
+    /** ID of the channel on which the message was sent. */
+    channelID: string;
+    /** Content of the message. */
+    content: string | null;
+    /** Array of message embed. */
+    embeds?: Array<APIEmbedOptions> | [];
+    /** The IDs of the message replied by the message. */
+    replyMessageIds: Array<string>;
+    /** If true, the message appears as private. */
+    isPrivate: boolean;
+    /** If true, the message didn't mention anyone. */
+    isSilent: boolean;
+    /** object containing all mentioned users. */
+    mentions: APIMentions;
+    /** ID of the message author. */
+    memberID: string;
+    /** ID of the webhook used to send this message. (if sent by a webhook) */
+    webhookID?: string | null;
+    /** When the message was created. */
+    createdAt: Date;
+    /** Timestamp at which this message was last edited. */
+    editedTimestamp: Date | null;
+    /** When the message was deleted. */
+    deletedAt: Date | null;
+}
+
+export interface JSONForumThreadComment extends JSONBase<number> {
+    /** The content of the forum thread comment */
+    content: string;
+    /** The ISO 8601 timestamp that the forum thread comment was created at */
+    createdAt: Date;
+    /** The ISO 8601 timestamp that the forum thread comment was updated at, if relevant */
+    updatedAt: Date | null;
+    /** The ID of the forum thread */
+    threadID: number;
+    /** The ID of the user who sent this comment. */
+    memberID: string;
+    /** ID of the forum thread's server, if provided. */
+    guildID: string | null;
+    /** ID of the forum channel containing this thread. */
+    channelID: string;
+    /** Mentions in this thread comment. */
+    mentions: APIMentions | null;
+}
+
+export interface JSONDoc extends JSONBase<number> {
+    /** Guild/server id */
+    guildID: string;
+    /** ID of the 'docs' channel. */
+    channelID: string;
+    /** Doc name */
+    name: string;
+    /** Content of the doc */
+    content: string;
+    /** Doc mentions  */
+    mentions: APIMentions;
+    /** When the doc has been created. */
+    createdAt: Date;
+    /** ID of the member who created this doc. */
+    memberID: string;
+    /** When the doc has been updated. */
+    editedTimestamp: Date | null;
+    /** ID of the member who updated the doc. */
+    updatedBy: string | null;
+}
+
+export interface JSONChannel extends JSONBase<string> {
+    /** Channel type */
+    type: string;
+    /** Channel name */
+    name: string | null;
+}
+
+export interface JSONGuildChannel extends JSONBase<string> {
+    /** Channel type */
+    type: string;
+    /** Channel name */
+    name: string;
+    /** Channel description */
+    description: string | null;
+    /** When this channel was created. */
+    createdAt: Date;
+    /** ID of the member who created this channel. */
+    creatorID: string;
+    /** Timestamp at which this channel was last edited. */
+    editedTimestamp: Date | null;
+    /** Server ID */
+    guildID: string;
+    /** ID of the parent category. */
+    parentID: string | null;
+    /** ID of the category the channel is in. */
+    categoryID: number | null;
+    /** ID of the group the channel is in. */
+    groupID: string;
+    isPublic: boolean;
+    /** ID of the member that archived the channel (if archived) */
+    archivedBy: string | null;
+    /** When the channel was last archived. */
+    archivedAt: Date | null;
+}
+
+export interface JSONTextChannel extends JSONGuildChannel {
+    /** Cached messages. */
+    messages: TypedCollection<string, APIChatMessage, Message>;
+}
+
+export interface JSONForumChannel extends JSONGuildChannel {
+    /** Cached threads. */
+    threads: TypedCollection<number, APIForumTopic, ForumThread>;
+}
+
+export interface JSONDocChannel extends JSONGuildChannel {
+    /** Cached docs. */
+    docs: TypedCollection<number, APIDoc, Doc>;
+}
+
+export interface JSONCalendarChannel extends JSONGuildChannel {
+    /** Cached scheduled events. */
+    scheduledEvents: TypedCollection<number, APICalendarEvent, CalendarEvent>;
+}
+
+export interface JSONCalendarEvent extends JSONBase<number> {
+    /** Raw data */
+    data: APICalendarEvent;
+    /** Guild/server ID */
+    guildID: string;
+    /** ID of the channel the event was created on. */
+    channelID: string;
+    /** Name of the event */
+    name: string;
+    /** Event's description */
+    description: string | null;
+    /** Event user-specified location */
+    location: string | null;
+    /** Event user-specified url */
+    url: string | null;
+    /** Event color in calendar. */
+    color: number | null;
+    /** Limit of event entry. */
+    rsvpLimit: number | null;
+    /** Timestamp (unix epoch time) of the event starting time.*/
+    startsAt: Date | null;
+    /** Duration in *ms* of the event. */
+    duration: number;
+    /** If true, this event is private. */
+    isPrivate: boolean;
+    /** Mentions in this calendar event. */
+    mentions: APIMentions | null;
+    /** When the event was created. */
+    createdAt: Date | null;
+    /** ID of the owner of this event. */
+    ownerID: string;
+    /** Details about event cancelation (if canceled) */
+    cancelation: APICalendarEvent["cancellation"] | null;
+    /** Cached RSVPS. */
+    rsvps: TypedCollection<number, APICalendarEventRSVP, CalendarEventRSVP>;
+}
+
+export interface JSONCalendarEventRSVP extends JSONBase<number> {
+    /** Guild/server ID. */
+    guildID: string;
+    /** Calendar channel id. */
+    channelID: string;
+    /** ID of the entity assigned to this Event RSVP. */
+    entityID: string;
+    /** Status of the RSVP */
+    status: APICalendarEventRSVPStatuses;
+    /** When the RSVP was created. */
+    createdAt: Date | null;
+    /** ID of the user who created this RSVP. */
+    creatorID: string;
+    /** When the RSVP was updated. */
+    updatedAt: Date | null;
+    /** ID of the member who updated the rsvp, if updated. */
+    updatedBy?: string | null;
+}
+
+export interface JSONBannedMember extends JSONBase<string> {
+    /** Server ID. */
+    guildID: string;
+    /** Information about the banned member (object) */
+    ban: {
+        /** Reason of the ban */
+        reason?: string;
+        /** When the member has been banned. */
+        createdAt: Date | null;
+        /** ID of the member who banned this member. */
+        bannedBy: string;
+    };
+}
+
+export interface JSONForumThread extends JSONBase<number> {
+    /** Guild/server id */
+    guildID: string;
+    /** Forum channel id */
+    channelID: string;
+    /** Name of the thread */
+    name: string;
+    /** When this forum thread was created. */
+    createdAt: Date;
+    /** Owner of this thread, if cached. */
+    owner: T extends Guild ? Member : Member | User | Promise<Member> | undefined;
+    /** The ID of the owner of this thread. */
+    ownerID: string;
+    /** ID of the webhook that created the thread (if created by webhook) */
+    webhookID: string | null;
+    /** Timestamp at which this channel was last edited. */
+    editedTimestamp: Date | null;
+    /** Timestamp (unix epoch time) that the forum thread was bumped at. */
+    bumpedAt: Date | null;
+    /** Content of the thread */
+    content: string;
+    /** Thread mentions */
+    mentions: APIMentions | null;
+    /** Cached comments. */
+    comments: TypedCollection<number, APIForumTopicComment, ForumThreadComment>;
+    /** If true, the thread is locked. */
+    isLocked: boolean;
+    /** If true, the thread is pinned. */
+    isPinned: boolean;
+}
+
+export interface JSONUser extends JSONBase<string> {
+    /** User type */
+    type: UserTypes | null;
+    /** User's username. */
+    username: string;
+    /** Current avatar url of the user. */
+    avatarURL: string | null;
+    /** Current banned url of the user. */
+    bannerURL: string | null;
+    /** When the user account was created. */
+    createdAt: Date; // user
+    /** If true, the user is a bot. */
+    bot: boolean;
+}
+
+export interface JSONMember extends JSONUser {
+    /** When this member joined the guild. */
+    joinedAt: Date | null;
+    /** Array of member's roles. */
+    roles: Array<number>;
+    /** Member's server nickname. */
+    nickname: string | null;
+    /** Tells you if the member is the server owner. */
+    isOwner: boolean;
+    /** Server ID. */
+    guildID: string; // member
+}
+
+export interface JSONGuild extends JSONBase<string> {
+    /** ID of the guild owner. */
+    ownerID: string;
+    /** Guild type. */
+    type?: string;
+    /** The name of the guild. */
+    name: string;
+    /** The URL of the guild. */
+    url?: string;
+    /** Guild description. */
+    description?: string;
+    /** Guild icon URL. */
+    iconURL?: string | null;
+    /** Guild banner URL. */
+    bannerURL?: string | null;
+    /** Guild's timezone. */
+    timezone?: string;
+    /** Default channel of the guild. */
+    defaultChannelID?: string;
+    /** When this guild was created. */
+    createdAt: Date;
+    /** If true, the guild is verified. */
+    verified: boolean;
+    /** Cached guild channels. */
+    channels: TypedCollection<string, APIGuildChannel, Channel>;
+    /** Cached guild members. */
+    members: TypedCollection<string, APIGuildMember, Member, [guildID: string]>;
+}
+
+export interface JSONUserClient extends JSONBase<string> {
+    /** Client User Bot ID */
+    botID: string;
+    /** User type (user, bot) */
+    type: string;
+    /** User's name */
+    username: string;
+    /** When the bot client was created. */
+    createdAt: Date;
+    /** ID of the bot's owner. */
+    ownerID: string;
+}
+
+export interface JSONWebhook extends JSONBase<string> {
+    /** ID of the guild, where the webhook comes from. */
+    guildID: string;
+    /** ID of the channel, where the webhook comes from. */
+    channelID: string;
+    /** Username of the webhook. */
+    username: string;
+    /** When the webhook was created. */
+    createdAt: Date;
+    /** ID of the webhook's owner. */
+    ownerID: string;
+    /** When the webhook was deleted. */
+    deletedAt: Date | null;
+    /** Token of the webhook. */
+    token: string | null;
+}
+
+export interface JSONListItem extends JSONBase<string> {
+    /** Guild id */
+    guildID: string;
+    /** ID of the 'docs' channel. */
+    channelID: string;
+    /** Content of the doc */
+    content: string;
+    mentions: APIMentions | null;
+    /** When the item was created. */
+    createdAt: Date | null;
+    /** ID of the member who created the doc. */
+    memberID: string;
+    /** ID of the webhook that created the list item (if it was created by a webhook) */
+    webhookID: string | null;
+    /** Timestamp at which the item was updated. */
+    editedTimestamp: Date | null;
+    /** ID of the member who updated the doc. (if updated) */
+    updatedBy: string | null;
+    /** The ID of the parent list item if this list item is nested */
+    parentListItemID: string | null;
+    /** When the list item was marked as "completed". */
+    completedAt: Date | null;
+    /** ID of the member that completed the item, if completed. */
+    completedBy: string | null;
+}

--- a/lib/types/types.d.ts
+++ b/lib/types/types.d.ts
@@ -7,7 +7,7 @@ import type { MessageReactionInfo } from "../structures/MessageReactionInfo";
 import type { ForumThreadReactionInfo } from "../structures/ForumThreadReactionInfo";
 import type { APIEmote, APIMentions } from "../Constants";
 
-export interface messageReactionInfo {
+export interface MessageReactionTypes {
     message: Message | {
         id: string;
         guild: Guild | {
@@ -21,7 +21,7 @@ export interface messageReactionInfo {
     };
 }
 
-export interface forumThreadReactionInfo {
+export interface ForumThreadReactionTypes {
     thread: ForumThread | {
         id: number;
         guild: Guild | {
@@ -35,7 +35,6 @@ export interface forumThreadReactionInfo {
     };
 }
 
-// deprecated.
 export interface UserClientTypes {
     /** Client's user. */
     user: {
@@ -86,3 +85,4 @@ export interface GuildDeleteInfo {
 }
 
 export type AnyReactionInfo = MessageReactionInfo | ForumThreadReactionInfo;
+export interface Uncached<ID = string | number> { id: ID; }

--- a/lib/util/Util.ts
+++ b/lib/util/Util.ts
@@ -1,5 +1,42 @@
 /** @module Util */
 
+import { Client } from "../structures/Client";
+import { Member } from "../structures/Member";
+import { AnyChannel } from "../types/channel";
+import { Channel } from "../structures/Channel";
+import { APIGuildChannel, APIGuildMember } from "guildedapi-types.ts/v1";
+
+export class Util {
+    #client: Client;
+    constructor(client: Client) {
+        this.#client = client;
+    }
+
+    updateMember(guildID: string, memberID: string, member: APIGuildMember): Member {
+        const guild = this.#client.guilds.get(guildID);
+        if (guild && this.#client.user?.id === memberID) {
+            if (guild["_clientMember"]) {
+                guild["_clientMember"]["update"](member);
+            } else {
+                guild["_clientMember"] = guild.members.update({ ...member, id: memberID }, guildID);
+            }
+            return guild["_clientMember"];
+        }
+        return guild ? guild.members.update({ ...member, id: memberID }, guildID) : new Member({ ...member }, this.#client, guildID);
+    }
+
+    updateChannel<T extends AnyChannel>(data: APIGuildChannel): T {
+        if (data.serverId) {
+            const guild = this.#client.guilds.get(data.serverId);
+            if (guild) {
+                const channel = guild.channels.has(data.id) ? guild.channels.update(data as APIGuildChannel)  : guild.channels.add(Channel.from<AnyChannel>(data, this.#client));
+                return channel as T;
+            }
+        }
+        return Channel.from<T>(data, this.#client);
+    }
+}
+
 export function is<T>(input: unknown): input is T {
     return true;
 }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "typescript": "^4.9.3"
   },
   "dependencies": {
-    "guildedapi-types.ts": "0.2.7",
+    "guildedapi-types.ts": "0.2.8",
     "undici": "^5.12.0",
     "ws": "^8.11.0"
   },


### PR DESCRIPTION
Development build, early v.1.2.0

- Add guild to cache when receiving any event containing guild id.
- Add channel to cache when receiving any event containing a channel id.
- Add cache hierarchy (e.g: guild/channels/messages/message)
- Remove Client#cache, cache isn't entirely managed in Client anymore.
- Channel filters by channel types.
- Add `GuildChannel`, `TextChannel`, `DocChannel`, `ForumChannel`, `GuildChannel`, `CalendarChannel`.
- Add `Base#toJSON`, `ListItem#toJSON`, `Webhook#toJSON`, `UserClient#toJSON`, `Guild#toJSON`, `Member#toJSON`, `User#toJSON`, `ForumThread#toJSON`, `BannedMember#toJSON`, `CalendarEventRSVP#toJSON`, `CalendarEvent#toJSON`, `CalendarChannel#toJSON`, `DocChannel#toJSON`, `ForumChannel#toJSON`, `TextChannel#toJSON`, `GuildChannel#toJSON`, `Channel#toJSON`, `Doc#toJSON`, `ForumThreadComment#toJSON`, `Message#toJSON`
- Add AnyTextableChannel, AnyChannel, AnyGuildChannel typings.
- Add Client params: `collectionLimits` to configure cache.
- Update imports.
- Edit every handlers to match new caching system.
- Update REST methods to match new caching system & new components.
- Add update methods to every components for data update when receiving new data.
- Add `Client#guilds`
- Add `Client#users`
- Add `Client#util`
- Add `Client#startTime`
- Add `Client#uptime`
- Update `Client#getMember`, not sending rest request anymore.
- Update `Client#getMembers` not sending rest request anymore.
- Update `Client#getGuild` not sending rest request anymore.
- Update `Client#getMessage` not sending rest request anymore.
- Update `Client#getMessages` not sending rest request anymore.
- Update Doc#member, ForumThreadComment#member, Guild#owner, ListItem#member, Member#user, MemberUpdateInfo#oldRoles, Message#member
- Add `Guild#getMember`
- Add `Guild#verified`
- Add `Guild#channels`
- Add `Guild#members`

[Website](https://touchguild.com)
[Development documentation](https://docs.touchguild.com/dev)