### PR TITLE
rest methods caching

### DIFF
--- a/lib/routes/Guilds.ts
+++ b/lib/routes/Guilds.ts
@@ -46,7 +46,7 @@ export class Guilds {
         return this.#manager.authRequest<GETGuildResponse>({
             method: "GET",
             path:   endpoints.GUILD(guildID)
-        }).then(data => new Guild(data.server, this.#manager.client));
+        }).then(data => this.#manager.client.util.updateGuild(data.server));
     }
 
     /** This method is used to get a specific webhook.
@@ -80,11 +80,11 @@ export class Guilds {
      * @param guildID The ID of the Guild.
      * @param memberID The ID of the Guild Member to get.
      */
-    async getMember(guildID: string, memberID: string): Promise<Member>{
+    async getMember(guildID: string, memberID: string): Promise<Member> {
         return this.#manager.authRequest<GETGuildMemberResponse>({
             method: "GET",
             path:   endpoints.GUILD_MEMBER(guildID, memberID)
-        }).then(data => new Member(data.member, this.#manager.client, guildID));
+        }).then(data => this.#manager.client.util.updateMember(guildID, memberID, data.member));
     }
 
     /** This method is used to get a list of guild member.
@@ -94,7 +94,7 @@ export class Guilds {
         return this.#manager.authRequest<GETGuildMembersResponse>({
             method: "GET",
             path:   endpoints.GUILD_MEMBERS(guildID)
-        }).then(data => data.members.map(d => new Member(d as APIGuildMember, this.#manager.client, guildID)));
+        }).then(data => data.members.map(d => this.#manager.client.util.updateMember(guildID, d.user.id, d as APIGuildMember)));
     }
 
     /** Get a ban.

--- a/lib/structures/Client.ts
+++ b/lib/structures/Client.ts
@@ -18,6 +18,7 @@ import { ForumThreadComment } from "./ForumThreadComment";
 import { User } from "./User";
 import { BannedMember } from "./BannedMember";
 import { TextChannel } from "./TextChannel";
+import { ForumChannel } from "./ForumChannel";
 import { WSManager } from "../gateway/WSManager";
 import { GatewayHandler } from "../gateway/GatewayHandler";
 import { RESTManager } from "../rest/RESTManager";
@@ -246,7 +247,7 @@ export class Client extends TypedEmitter<ClientEvents> {
      * @param channelID ID of a "Forum" channel.
      * @param filter Object to filter the output.
      */
-    async getForumThreads(channelID: string, filter?: GetForumThreadsFilter): Promise<Array<ForumThread<AnyTextableChannel>>>{
+    async getForumThreads(channelID: string, filter?: GetForumThreadsFilter): Promise<Array<ForumThread<ForumChannel>>>{
         return this.rest.channels.getForumThreads(channelID, filter);
     }
 
@@ -256,7 +257,7 @@ export class Client extends TypedEmitter<ClientEvents> {
      * @param channelID ID of a speific Forum channel.
      * @param threadID ID of the specific Forum Thread.
      */
-    async getForumThread(channelID: string, threadID: number): Promise<ForumThread<AnyTextableChannel>>{
+    async getForumThread(channelID: string, threadID: number): Promise<ForumThread<ForumChannel>>{
         return this.rest.channels.getForumThread(channelID, threadID);
     }
 
@@ -426,7 +427,7 @@ export class Client extends TypedEmitter<ClientEvents> {
      * @param channelID ID of a "Forums" channel.
      * @param options Thread's options including title & content.
      */
-    async createForumThread<T extends AnyChannel = AnyChannel>(channelID: string, options: CreateForumThreadOptions): Promise<ForumThread<T>> {
+    async createForumThread<T extends ForumChannel = ForumChannel>(channelID: string, options: CreateForumThreadOptions): Promise<ForumThread<T>> {
         return this.rest.channels.createForumThread<T>(channelID, options);
     }
 
@@ -435,7 +436,7 @@ export class Client extends TypedEmitter<ClientEvents> {
      * @param threadID ID of a forum thread.
      * @param options Edit options.
      */
-    async editForumThread<T extends AnyChannel = AnyChannel>(channelID: string, threadID: number, options: EditForumThreadOptions): Promise<ForumThread<T>>{
+    async editForumThread<T extends ForumChannel = ForumChannel>(channelID: string, threadID: number, options: EditForumThreadOptions): Promise<ForumThread<T>>{
         return this.rest.channels.editForumThread<T>(channelID, threadID, options);
     }
 

--- a/lib/structures/ForumChannel.ts
+++ b/lib/structures/ForumChannel.ts
@@ -3,7 +3,6 @@ import { Client } from "./Client";
 
 import { ForumThread } from "./ForumThread";
 import { GuildChannel } from "./GuildChannel";
-import { AnyChannel } from "../types/channel";
 import type { APIForumTopic, APIGuildChannel } from "../Constants";
 import TypedCollection from "../util/TypedCollection";
 import { JSONForumChannel } from "../types/json";
@@ -11,7 +10,7 @@ import { JSONForumChannel } from "../types/json";
 /** Represents a forum channel. */
 export class ForumChannel extends GuildChannel {
     /** Cached threads. */
-    threads: TypedCollection<number, APIForumTopic, ForumThread<AnyChannel>>;
+    threads: TypedCollection<number, APIForumTopic, ForumThread<ForumChannel>>;
     /**
      * @param data raw data
      * @param client client

--- a/lib/structures/ForumThread.ts
+++ b/lib/structures/ForumThread.ts
@@ -5,15 +5,16 @@ import { Member } from "./Member";
 import { Base } from "./Base";
 import { User } from "./User";
 import { ForumThreadComment } from "./ForumThreadComment";
+import { ForumChannel } from "./ForumChannel";
 import { APIForumTopic, APIForumTopicComment, APIMentions } from "../Constants";
 import { EditForumThreadOptions } from "../types/forumThread";
 import { CreateForumCommentOptions } from "../types/forumThreadComment";
 import TypedCollection from "../util/TypedCollection";
 import { JSONForumThread } from "../types/json";
-import { AnyChannel, AnyTextableChannel } from "../types/channel";
+import { AnyTextableChannel } from "../types/channel";
 
 /** Represents a thread/topic coming from a "Forums" channel. */
-export class ForumThread<T extends AnyChannel> extends Base<number> {
+export class ForumThread<T extends ForumChannel> extends Base<number> {
     private _cachedChannel!: T extends AnyTextableChannel ? T : undefined;
     private _cachedGuild?: T extends Guild ? Guild : Guild | null;
     /** Guild ID */


### PR DESCRIPTION
- ForumChannel#cache only supports ForumChannel.
- `ForumThread<T extends AnyChannel>` -> `ForumThread<T extends ForumChannel>`
- Updating cached data through rest requests.

Note: Client#getMember, Client#getMembers, Client#getChannel, Client#getGuild are synchronous methods and they retrieve cached data, to get uncached data use rest methods: Client#rest